### PR TITLE
fix(lint): recognize lit boolean binding on popover hidden attribute

### DIFF
--- a/projects/lint/src/eslint/rules/no-missing-popover-trigger.test.ts
+++ b/projects/lint/src/eslint/rules/no-missing-popover-trigger.test.ts
@@ -73,6 +73,20 @@ describe('noMissingPopoverTrigger', () => {
     });
   });
 
+  it('should allow popover elements with data binding on hidden attribute', () => {
+    tester.run('data binding on hidden attribute', rule, {
+      valid: [
+        // Lit boolean-attribute binding
+        '<nve-dropdown id="dropdown" ?hidden="${isHidden}"></nve-dropdown>',
+        // Lit property binding
+        '<nve-tooltip id="tooltip" .hidden="${isHidden}">Content</nve-tooltip>',
+        // Angular property binding
+        '<nve-toggletip id="toggletip" [hidden]="isHidden">Content</nve-toggletip>'
+      ],
+      invalid: []
+    });
+  });
+
   it('should allow popover elements with commandfor trigger', () => {
     tester.run('valid commandfor triggers', rule, {
       valid: [

--- a/projects/lint/src/eslint/rules/no-missing-popover-trigger.ts
+++ b/projects/lint/src/eslint/rules/no-missing-popover-trigger.ts
@@ -51,6 +51,12 @@ function findAttrWithBinding(
     return { attr: litAttr, hasBinding: true };
   }
 
+  // Check for Lit boolean-attribute binding: ?attrName
+  const litBoolAttr = findAttr(node, `?${attrName}`);
+  if (litBoolAttr) {
+    return { attr: litBoolAttr, hasBinding: true };
+  }
+
   return { attr: undefined, hasBinding: false };
 }
 
@@ -125,7 +131,7 @@ const rule = {
       if (!POPOVER_ELEMENTS.includes(tagName as (typeof POPOVER_ELEMENTS)[number])) return;
       const { attr: idAttr, hasBinding: hasBindingId } = findAttrWithBinding(node, 'id');
       const anchorAttr = findAttr(node, 'anchor');
-      const hiddenAttr = findAttr(node, 'hidden');
+      const { attr: hiddenAttr } = findAttrWithBinding(node, 'hidden');
       popovers.push({
         node,
         id: idAttr?.value?.value,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Popover validation now correctly recognizes popovers hidden via template or boolean bindings (e.g., Lit/Angular), preventing false positive warnings when elements are dynamically hidden.
* **Tests**
  * Added tests to cover Lit boolean-attribute and property bindings and Angular property binding so these hidden-state cases are validated as allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->