### PR TITLE
feat(lint): add rules to disallow slotted popovers and tailwind classes

### DIFF
--- a/projects/core/src/page/page.examples.ts
+++ b/projects/core/src/page/page.examples.ts
@@ -620,7 +620,7 @@ export const InteractionDrawer = {
     <p nve-text="body">page content</p>
   </main>
 
-  <nve-drawer id="drawer" slot="left-aside" position="left" size="sm" closable style="--top: 48px">
+  <nve-drawer id="drawer" position="left" size="sm" closable style="--top: 48px">
     <nve-drawer-header>
       <h3 nve-text="heading medium sm">Drawer Header</h3>
     </nve-drawer-header>

--- a/projects/lint/README.md
+++ b/projects/lint/README.md
@@ -83,6 +83,8 @@ export default [
 | `@nvidia-elements/lint/no-nested-container-types` | Require nested container components to use flat container mode. | HTML | `error` |
 | `@nvidia-elements/lint/no-restricted-attributes` | Disallow use of invalid API attributes or utility attributes on custom HTML element tags. | HTML | `error` |
 | `@nvidia-elements/lint/no-restricted-page-sizing` | Disallow custom height or width styles on nve-page. | HTML | `error` |
+| `@nvidia-elements/lint/no-slotted-popovers` | Disallow the slot attribute on popover elements (nve-tooltip, nve-dialog, nve-drawer, ...). | HTML | `error` |
+| `@nvidia-elements/lint/no-tailwind-classes` | Disallow Tailwind CSS utility classes with Elements alternatives, and all Tailwind utilities on nve custom elements. | HTML | `warn` |
 | `@nvidia-elements/lint/no-unexpected-attribute-value` | Disallow use of invalid attribute values for nve-* elements. | HTML | `error` |
 | `@nvidia-elements/lint/no-unexpected-css-value` | Disallow use of invalid CSS values. | CSS | `error` |
 | `@nvidia-elements/lint/no-unexpected-css-variable` | Disallow use of invalid CSS theme variables. | CSS | `error` |

--- a/projects/lint/src/eslint/configs/html.ts
+++ b/projects/lint/src/eslint/configs/html.ts
@@ -13,6 +13,7 @@ import noUnexpectedStyleCustomization from '../rules/no-unexpected-style-customi
 import noDeprecatedGlobalAttributeValue from '../rules/no-deprecated-global-attribute-value.js';
 import noDeprecatedGlobalAttributes from '../rules/no-deprecated-global-attributes.js';
 import noRestrictedAttributes from '../rules/no-restricted-attributes.js';
+import noSlottedPopovers from '../rules/no-slotted-popovers.js';
 import noDeprecatedSlots from '../rules/no-deprecated-slots.js';
 import noMissingSlottedElements from '../rules/no-missing-slotted-elements.js';
 import noMissingControlLabel from '../rules/no-missing-control-label.js';
@@ -29,6 +30,7 @@ import noUnknownCssVariable from '../rules/no-unknown-css-variable.js';
 import noRestrictedPageSizing from '../rules/no-restricted-page-sizing.js';
 import noNestedContainerTypes from '../rules/no-nested-container-types.js';
 import noUnstyledTypography from '../rules/no-unstyled-typography.js';
+import noTailwindClasses from '../rules/no-tailwind-classes.js';
 
 const source = ['src/**/*.html', 'src/**/*.js', 'src/**/*.ts', 'src/**/*.tsx'];
 
@@ -71,6 +73,7 @@ export const elementsHtmlConfig: Linter.Config = {
         'no-missing-popover-trigger': noMissingPopoverTrigger,
         'no-restricted-attributes': noRestrictedAttributes,
         'no-restricted-page-sizing': noRestrictedPageSizing,
+        'no-slotted-popovers': noSlottedPopovers,
         'no-unexpected-global-attribute-value': noUnexpectedGlobalAttributeValue,
         'no-unexpected-style-customization': noUnexpectedStyleCustomization,
         'no-unexpected-slot-value': noUnexpectedSlotValue,
@@ -82,13 +85,13 @@ export const elementsHtmlConfig: Linter.Config = {
         'no-missing-gap-space': noMissingGapSpace,
         'no-unknown-css-variable': noUnknownCssVariable,
         'no-nested-container-types': noNestedContainerTypes,
-        'no-unstyled-typography': noUnstyledTypography
+        'no-unstyled-typography': noUnstyledTypography,
+        'no-tailwind-classes': noTailwindClasses
       }
     }
   },
   rules: {
     '@nvidia-elements/lint/no-complex-popovers': ['error'],
-    '@nvidia-elements/lint/no-unexpected-style-customization': ['off'],
     '@nvidia-elements/lint/no-deprecated-tags': ['error'],
     '@nvidia-elements/lint/no-deprecated-attributes': ['error'],
     '@nvidia-elements/lint/no-deprecated-icon-names': ['error'],
@@ -102,6 +105,7 @@ export const elementsHtmlConfig: Linter.Config = {
     '@nvidia-elements/lint/no-missing-popover-trigger': ['error'],
     '@nvidia-elements/lint/no-restricted-attributes': ['error'],
     '@nvidia-elements/lint/no-restricted-page-sizing': ['error'],
+    '@nvidia-elements/lint/no-slotted-popovers': ['error'],
     '@nvidia-elements/lint/no-unexpected-global-attribute-value': ['error'],
     '@nvidia-elements/lint/no-unexpected-slot-value': ['error'],
     '@nvidia-elements/lint/no-unknown-tags': ['error'],
@@ -109,9 +113,11 @@ export const elementsHtmlConfig: Linter.Config = {
     '@nvidia-elements/lint/no-unexpected-input-type': ['error'],
     '@nvidia-elements/lint/no-invalid-event-listeners': ['error'],
     '@nvidia-elements/lint/no-invalid-invoker-triggers': ['error'],
-    '@nvidia-elements/lint/no-missing-gap-space': ['off'],
     '@nvidia-elements/lint/no-unknown-css-variable': ['error'],
     '@nvidia-elements/lint/no-nested-container-types': ['error'],
-    '@nvidia-elements/lint/no-unstyled-typography': ['error']
+    '@nvidia-elements/lint/no-unstyled-typography': ['error'],
+    '@nvidia-elements/lint/no-tailwind-classes': ['error'],
+    '@nvidia-elements/lint/no-unexpected-style-customization': ['off'],
+    '@nvidia-elements/lint/no-missing-gap-space': ['off']
   }
 };

--- a/projects/lint/src/eslint/internals/index.ts
+++ b/projects/lint/src/eslint/internals/index.ts
@@ -26,17 +26,23 @@ export interface TemplateLintMessage {
 
 export async function lintPlaygroundTemplate(code: string): Promise<TemplateLintMessage[]> {
   // extra restrictions/rules as agents rarely use these advanced APIs correctly for playground generation out of context of an established project
-  // '@nvidia-elements/lint/no-unexpected-style-customization': ['error']
   const rules: Partial<Linter.RulesRecord> = {
-    '@nvidia-elements/lint/no-unexpected-global-attribute-value': ['error', { distilled: true }],
+    '@nvidia-elements/lint/no-unexpected-style-customization': ['error'],
+    '@nvidia-elements/lint/no-missing-gap-space': ['error'],
     '@nvidia-elements/lint/no-missing-slotted-elements': ['error', { 'nve-card': { required: ['nve-card-content'] } }],
-    '@nvidia-elements/lint/no-missing-gap-space': ['error']
+    '@nvidia-elements/lint/no-unexpected-global-attribute-value': ['error', { distilled: true }],
+    '@nvidia-elements/lint/no-tailwind-classes': ['error', { strict: true }]
   };
   return lintString(code, rules);
 }
 
 export async function lintTemplate(code: string): Promise<TemplateLintMessage[]> {
-  return lintString(code);
+  const rules: Partial<Linter.RulesRecord> = {
+    '@nvidia-elements/lint/no-unexpected-global-attribute-value': ['error', { distilled: true }],
+    '@nvidia-elements/lint/no-tailwind-classes': ['warn', { strict: true }],
+    '@nvidia-elements/lint/no-missing-gap-space': ['warn']
+  };
+  return lintString(code, rules);
 }
 
 async function lintString(code: string, rules: Partial<Linter.RulesRecord> = {}): Promise<TemplateLintMessage[]> {

--- a/projects/lint/src/eslint/internals/tailwind.ts
+++ b/projects/lint/src/eslint/internals/tailwind.ts
@@ -1,0 +1,439 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Standalone Tailwind utility tokens that have no `-` suffix. Limited to tokens
+ * unambiguous in the Elements context. `container` is deliberately excluded —
+ * too common as a custom semantic class.
+ */
+export const STANDALONE_TAILWIND_CLASSES: ReadonlySet<string> = new Set([
+  'flex',
+  'inline-flex',
+  'grid',
+  'inline-grid',
+  'block',
+  'inline',
+  'inline-block',
+  'hidden',
+  'contents',
+  'flow-root',
+  'truncate',
+  'italic',
+  'not-italic',
+  'underline',
+  'no-underline',
+  'uppercase',
+  'lowercase',
+  'capitalize',
+  'sr-only',
+  'not-sr-only',
+  'pointer-events-none',
+  'pointer-events-auto',
+  'select-none',
+  'select-text',
+  'cursor-pointer',
+  'cursor-default',
+  'cursor-not-allowed',
+  'static',
+  'fixed',
+  'absolute',
+  'relative',
+  'sticky',
+  'visible',
+  'invisible',
+  'overflow-hidden',
+  'overflow-visible',
+  'overflow-scroll',
+  'overflow-auto',
+  'whitespace-nowrap',
+  'whitespace-normal',
+  'whitespace-pre',
+  'break-normal',
+  'break-words',
+  'break-all',
+  'rounded',
+  'rounded-full',
+  'rounded-none',
+  'border',
+  'shadow',
+  'shadow-sm',
+  'shadow-md',
+  'shadow-lg',
+  'shadow-xl',
+  'shadow-none',
+  'ring',
+  'transition',
+  'transform',
+  'flex-row',
+  'flex-col',
+  'flex-wrap',
+  'flex-nowrap',
+  'items-center',
+  'items-start',
+  'items-end',
+  'items-stretch',
+  'items-baseline',
+  'justify-center',
+  'justify-start',
+  'justify-end',
+  'justify-between',
+  'justify-around',
+  'justify-evenly',
+  'self-auto',
+  'self-start',
+  'self-end',
+  'self-center',
+  'self-stretch',
+  'text-left',
+  'text-center',
+  'text-right',
+  'text-justify',
+  'antialiased',
+  'subpixel-antialiased'
+]);
+
+const TAILWIND_PREFIXES: ReadonlySet<string> = new Set([
+  'underline-offset',
+  'place-content',
+  'place-items',
+  'place-self',
+  'translate-x',
+  'translate-y',
+  'ring-offset',
+  'hue-rotate',
+  'rounded-tl',
+  'rounded-tr',
+  'rounded-br',
+  'rounded-bl',
+  'col-start',
+  'col-span',
+  'col-end',
+  'row-start',
+  'row-span',
+  'row-end',
+  'auto-cols',
+  'auto-rows',
+  'grid-cols',
+  'grid-rows',
+  'rounded-t',
+  'rounded-r',
+  'rounded-b',
+  'rounded-l',
+  'border-t',
+  'border-r',
+  'border-b',
+  'border-l',
+  'border-s',
+  'border-e',
+  'border-x',
+  'border-y',
+  'inset-x',
+  'inset-y',
+  'divide-x',
+  'divide-y',
+  'space-x',
+  'space-y',
+  'min-w',
+  'min-h',
+  'max-w',
+  'max-h',
+  'scale-x',
+  'scale-y',
+  'skew-x',
+  'skew-y',
+  'gap-x',
+  'gap-y',
+  'animate',
+  'aspect',
+  'basis',
+  'cursor',
+  'accent',
+  'caret',
+  'placeholder',
+  'decoration',
+  'rounded',
+  'shadow',
+  'border',
+  'divide',
+  'outline',
+  'opacity',
+  'leading',
+  'tracking',
+  'transition',
+  'duration',
+  'delay',
+  'sepia',
+  'saturate',
+  'contrast',
+  'brightness',
+  'rotate',
+  'scale',
+  'content',
+  'order',
+  'right',
+  'left',
+  'inset',
+  'fill',
+  'stroke',
+  'gap',
+  'top',
+  'ring',
+  'flex',
+  'grow',
+  'shrink',
+  'font',
+  'text',
+  'size',
+  'ease',
+  'blur',
+  'from',
+  'via',
+  'col',
+  'row',
+  'bg',
+  'px',
+  'py',
+  'pt',
+  'pr',
+  'pb',
+  'pl',
+  'ps',
+  'pe',
+  'mx',
+  'my',
+  'mt',
+  'mr',
+  'mb',
+  'ml',
+  'ms',
+  'me',
+  'to',
+  'p',
+  'm',
+  'w',
+  'h',
+  'z'
+]);
+
+/**
+ * Matches a Tailwind utility value (the segment after `<prefix>-`). Covers
+ * numbers and fractions (`4`, `0.5`, `1/2`), size keywords (`xs`...`9xl`,
+ * `full`, `screen`, `auto`), color shades (`red-500`, `blue-700/50`), font and
+ * tracking keywords, alignment keywords, and arbitrary values (`[#ff0000]`).
+ * Custom kebab-case words (`card`, `custom-class`) deliberately fall through.
+ */
+const TAILWIND_VALUE_PATTERN = new RegExp(
+  '^(?:' +
+    [
+      String.raw`\d+(?:\.\d+)?(?:\/\d+)?`,
+      'xs',
+      'sm',
+      'md',
+      'lg',
+      'xl',
+      String.raw`[2-9]xl`,
+      'full',
+      'screen',
+      'min',
+      'max',
+      'fit',
+      'auto',
+      'none',
+      'px',
+      'inherit',
+      'current',
+      'transparent',
+      'black',
+      'white',
+      'sans',
+      'serif',
+      'mono',
+      'thin',
+      'light',
+      'normal',
+      'medium',
+      'semibold',
+      'bold',
+      'extrabold',
+      'tight',
+      'tighter',
+      'wide',
+      'wider',
+      'widest',
+      'snug',
+      'loose',
+      'relaxed',
+      'square',
+      'video',
+      'solid',
+      'dashed',
+      'dotted',
+      'wavy',
+      'double',
+      'baseline',
+      'top',
+      'middle',
+      'bottom',
+      'start',
+      'end',
+      'center',
+      'stretch',
+      String.raw`(?:red|blue|green|yellow|orange|purple|pink|gray|grey|slate|zinc|neutral|stone|amber|lime|emerald|teal|cyan|sky|indigo|violet|fuchsia|rose)-\d+(?:\/\d+)?`,
+      String.raw`\[[^\]]+\]`
+    ].join('|') +
+    ')$'
+);
+
+/**
+ * Mapping from common Tailwind tokens to their Elements counterpart. Enriches
+ * diagnostic messages when the bare token matches a key. The table stays small
+ * and curated; tokens outside the map fall back to a generic message.
+ */
+export const HINTS: Record<string, string> = {
+  flex: 'nve-layout="row"',
+  'inline-flex': 'nve-layout="row"',
+  grid: 'nve-layout="grid"',
+  hidden: 'nve-display="hide"',
+  block: 'nve-display="block"',
+  'flex-row': 'nve-layout="row"',
+  'flex-col': 'nve-layout="column"',
+  'items-center': 'nve-layout="align:center"',
+  'items-start': 'nve-layout="align:top"',
+  'items-end': 'nve-layout="align:bottom"',
+  'justify-center': 'nve-layout="align:center"',
+  'justify-between': 'nve-layout="align:space-between"',
+  'text-xs': 'nve-text="xs"',
+  'text-sm': 'nve-text="sm"',
+  'text-base': 'nve-text="body"',
+  'text-lg': 'nve-text="lg"',
+  'text-xl': 'nve-text="xl"',
+  'text-2xl': 'nve-text="heading"'
+};
+
+/**
+ * Tailwind utilities that are safe on `nve-*` host elements because they affect
+ * element placement or visibility instead of trying to style shadow DOM content.
+ */
+const NVE_HOST_STANDALONE_TAILWIND_CLASSES: ReadonlySet<string> = new Set([
+  'hidden',
+  'visible',
+  'invisible',
+  'sr-only',
+  'not-sr-only',
+  'static',
+  'fixed',
+  'absolute',
+  'relative',
+  'sticky',
+  'grow',
+  'shrink'
+]);
+
+const NVE_HOST_TAILWIND_PREFIXES: ReadonlySet<string> = new Set([
+  'inset-x',
+  'inset-y',
+  'basis',
+  'order',
+  'right',
+  'bottom',
+  'left',
+  'inset',
+  'self',
+  'grow',
+  'shrink',
+  'top',
+  'mx',
+  'my',
+  'mt',
+  'mr',
+  'mb',
+  'ml',
+  'ms',
+  'me',
+  'm',
+  'z'
+]);
+
+/**
+ * Strip Tailwind variant prefixes (`hover:`, `md:`, `dark:`, `[&:hover]:`),
+ * the `!` important modifier, and a leading `-` for negative utilities. Returns
+ * the bare utility name suitable for matching against the detector.
+ */
+export function stripVariantsAndModifiers(token: string): string {
+  let depth = 0;
+  let lastColon = -1;
+  for (let i = 0; i < token.length; i++) {
+    const c = token[i];
+    if (c === '[') depth++;
+    else if (c === ']') depth--;
+    else if (c === ':' && depth === 0) lastColon = i;
+  }
+  let bare = lastColon >= 0 ? token.slice(lastColon + 1) : token;
+  if (bare.startsWith('!')) bare = bare.slice(1);
+  if (bare.startsWith('-')) bare = bare.slice(1);
+  return bare;
+}
+
+export function isAllowedNveHostTailwindToken(bare: string): boolean {
+  if (!bare) return false;
+  if (NVE_HOST_STANDALONE_TAILWIND_CLASSES.has(bare)) return true;
+
+  const bracketIdx = bare.indexOf('[');
+  if (bracketIdx > 0 && bare.endsWith(']')) {
+    const prefixPart = bare.slice(0, bracketIdx).replace(/-$/, '');
+    return NVE_HOST_TAILWIND_PREFIXES.has(prefixPart);
+  }
+
+  let dashIdx = bare.indexOf('-');
+  while (dashIdx > 0) {
+    const prefix = bare.slice(0, dashIdx);
+    if (NVE_HOST_TAILWIND_PREFIXES.has(prefix)) {
+      return true;
+    }
+    dashIdx = bare.indexOf('-', dashIdx + 1);
+  }
+
+  return false;
+}
+
+const CSS_PROPERTY_NAME_PATTERN = /^(?:-?[a-z][\w-]*|--[\w-]+)$/i;
+
+function isBracketedArbitraryProperty(bare: string): boolean {
+  if (!bare.startsWith('[') || !bare.endsWith(']')) return false;
+
+  const arbitraryProperty = bare.slice(1, -1);
+  const colonIdx = arbitraryProperty.indexOf(':');
+  if (colonIdx <= 0 || colonIdx >= arbitraryProperty.length - 1) return false;
+
+  const propertyName = arbitraryProperty.slice(0, colonIdx);
+  return CSS_PROPERTY_NAME_PATTERN.test(propertyName);
+}
+
+/**
+ * Returns true when the bare token is a standalone Tailwind keyword, a
+ * bracketed arbitrary property, or splits into a known Tailwind prefix and a
+ * Tailwind-shaped value.
+ */
+export function isTailwindToken(bare: string): boolean {
+  if (!bare) return false;
+  if (STANDALONE_TAILWIND_CLASSES.has(bare)) return true;
+  if (isBracketedArbitraryProperty(bare)) return true;
+
+  const bracketIdx = bare.indexOf('[');
+  if (bracketIdx > 0 && bare.endsWith(']')) {
+    const prefixPart = bare.slice(0, bracketIdx).replace(/-$/, '');
+    if (TAILWIND_PREFIXES.has(prefixPart)) return true;
+  }
+
+  let dashIdx = bare.indexOf('-');
+  while (dashIdx > 0) {
+    const prefix = bare.slice(0, dashIdx);
+    const value = bare.slice(dashIdx + 1);
+    if (TAILWIND_PREFIXES.has(prefix) && TAILWIND_VALUE_PATTERN.test(value)) {
+      return true;
+    }
+    dashIdx = bare.indexOf('-', dashIdx + 1);
+  }
+
+  return false;
+}

--- a/projects/lint/src/eslint/rules/no-slotted-popovers.test.ts
+++ b/projects/lint/src/eslint/rules/no-slotted-popovers.test.ts
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RuleTester } from 'eslint';
+import type { JSRuleDefinition } from 'eslint';
+import htmlParser from '@html-eslint/parser';
+import noSlottedPopovers from './no-slotted-popovers.js';
+
+const rule = noSlottedPopovers as unknown as JSRuleDefinition;
+
+describe('noSlottedPopovers', () => {
+  let tester: RuleTester;
+
+  beforeEach(() => {
+    tester = new RuleTester({
+      languageOptions: {
+        parser: htmlParser,
+        parserOptions: {
+          frontmatter: true
+        }
+      }
+    });
+  });
+
+  it('should define rule metadata', () => {
+    expect(noSlottedPopovers.meta).toBeDefined();
+    expect(noSlottedPopovers.meta.type).toBe('problem');
+    expect(noSlottedPopovers.meta.docs).toBeDefined();
+    expect(noSlottedPopovers.meta.docs.description).toBe('Disallow the slot attribute on popover elements.');
+    expect(noSlottedPopovers.meta.docs.category).toBe('Best Practice');
+    expect(noSlottedPopovers.meta.docs.recommended).toBe(true);
+    expect(noSlottedPopovers.meta.docs.url).toContain('/docs/lint/');
+    expect(noSlottedPopovers.meta.schema).toBeDefined();
+    expect(noSlottedPopovers.meta.messages).toBeDefined();
+    expect(noSlottedPopovers.meta.messages['no-slotted-popover']).toContain('Unexpected slot attribute');
+  });
+
+  it('should allow popover elements without a slot attribute', () => {
+    tester.run('should allow popover elements without a slot attribute', rule, {
+      valid: [
+        '<nve-tooltip></nve-tooltip>',
+        '<nve-dialog id="d"></nve-dialog>',
+        '<nve-drawer><div>content</div></nve-drawer>',
+        '<nve-toast id="t"></nve-toast>',
+        '<nve-dropdown></nve-dropdown>'
+      ],
+      invalid: []
+    });
+  });
+
+  it('should allow non-popover elements with a slot attribute', () => {
+    tester.run('should allow non-popover elements with a slot attribute', rule, {
+      valid: [
+        '<div slot="header"></div>',
+        '<span slot=""></span>',
+        '<nve-button slot="actions"></nve-button>',
+        '<nve-icon slot="prefix" name="check"></nve-icon>',
+        '<section slot="${name}"></section>'
+      ],
+      invalid: []
+    });
+  });
+
+  it('should report a static slot value on a popover element', () => {
+    tester.run('should report a static slot value on a popover element', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<nve-tooltip slot="header"></nve-tooltip>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-tooltip' } }]
+        }
+      ]
+    });
+  });
+
+  it('should report an empty slot value on a popover element', () => {
+    tester.run('should report an empty slot value on a popover element', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<nve-tooltip slot=""></nve-tooltip>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-tooltip' } }]
+        }
+      ]
+    });
+  });
+
+  it('should report a whitespace-only slot value on a popover element', () => {
+    tester.run('should report a whitespace-only slot value on a popover element', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<nve-tooltip slot="   "></nve-tooltip>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-tooltip' } }]
+        }
+      ]
+    });
+  });
+
+  it('should report template-bound slot values on popover elements', () => {
+    tester.run('should report template-bound slot values on popover elements', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<nve-tooltip slot="${name}"></nve-tooltip>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-tooltip' } }]
+        },
+        {
+          code: '<nve-dialog slot="{{name}}"></nve-dialog>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-dialog' } }]
+        }
+      ]
+    });
+  });
+
+  it('should report a bare slot attribute on a popover element', () => {
+    tester.run('should report a bare slot attribute on a popover element', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<nve-tooltip slot></nve-tooltip>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-tooltip' } }]
+        }
+      ]
+    });
+  });
+
+  it('should report slot on every popover-behavior element', () => {
+    tester.run('should report slot on every popover-behavior element', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<nve-dialog slot="content"></nve-dialog>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-dialog' } }]
+        },
+        {
+          code: '<nve-drawer slot="aside"></nve-drawer>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-drawer' } }]
+        },
+        {
+          code: '<nve-dropdown slot="menu"></nve-dropdown>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-dropdown' } }]
+        },
+        {
+          code: '<nve-toast slot="notifications"></nve-toast>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-toast' } }]
+        },
+        {
+          code: '<nve-toggletip slot="hint"></nve-toggletip>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-toggletip' } }]
+        },
+        {
+          code: '<nve-notification slot="alerts"></nve-notification>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-notification' } }]
+        },
+        {
+          code: '<nve-notification-group slot="alerts"></nve-notification-group>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-notification-group' } }]
+        },
+        {
+          code: '<nve-page-loader slot="overlay"></nve-page-loader>',
+          errors: [{ messageId: 'no-slotted-popover', data: { tag: 'nve-page-loader' } }]
+        }
+      ]
+    });
+  });
+
+  it('should not report nested popovers without slot in a slotted wrapper', () => {
+    tester.run('should not report nested popovers without slot in a slotted wrapper', rule, {
+      valid: ['<div slot="content"><nve-tooltip></nve-tooltip></div>'],
+      invalid: []
+    });
+  });
+});

--- a/projects/lint/src/eslint/rules/no-slotted-popovers.ts
+++ b/projects/lint/src/eslint/rules/no-slotted-popovers.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Rule } from 'eslint';
+import { createVisitors } from '@html-eslint/eslint-plugin/lib/rules/utils/visitors.js';
+import { findAttr } from '@html-eslint/eslint-plugin/lib/rules/utils/node.js';
+import { elements } from '../internals/metadata.js';
+import type { HtmlTagNode } from '../rule-types.js';
+
+declare const __ELEMENTS_PAGES_BASE_URL__: string;
+
+const POPOVER_ELEMENTS: ReadonlySet<string> = new Set(
+  elements.filter(element => element.manifest?.metadata?.behavior === 'popover').map(element => element.name)
+);
+
+const rule = {
+  meta: {
+    type: 'problem' as const,
+    docs: {
+      description: 'Disallow the slot attribute on popover elements.',
+      category: 'Best Practice',
+      recommended: true,
+      url: `${__ELEMENTS_PAGES_BASE_URL__}/docs/lint/`
+    },
+    schema: [],
+    messages: {
+      ['no-slotted-popover']:
+        'Unexpected slot attribute on popover element <{{tag}}>. Named slots on a popover can cause rendering issues or hide it unexpectedly. Remove the slot attribute.'
+    }
+  },
+  create(context: Rule.RuleContext) {
+    return createVisitors(context, {
+      Tag(node: HtmlTagNode) {
+        if (!POPOVER_ELEMENTS.has(node.name?.toLowerCase() ?? '')) return;
+        const slotAttr = findAttr(node, 'slot');
+        if (!slotAttr) return;
+        context.report({
+          node: slotAttr,
+          messageId: 'no-slotted-popover',
+          data: { tag: node.name }
+        });
+      }
+    });
+  }
+} as const;
+
+export default rule;

--- a/projects/lint/src/eslint/rules/no-tailwind-classes.test.ts
+++ b/projects/lint/src/eslint/rules/no-tailwind-classes.test.ts
@@ -1,0 +1,614 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RuleTester } from 'eslint';
+import type { JSRuleDefinition } from 'eslint';
+import htmlParser from '@html-eslint/parser';
+import noTailwindClasses from './no-tailwind-classes.js';
+
+const rule = noTailwindClasses as unknown as JSRuleDefinition;
+
+describe('noTailwindClasses', () => {
+  let tester: RuleTester;
+
+  beforeEach(() => {
+    tester = new RuleTester({
+      languageOptions: {
+        parser: htmlParser,
+        parserOptions: {
+          frontmatter: true
+        }
+      }
+    });
+  });
+
+  it('should define rule metadata', () => {
+    expect(noTailwindClasses.meta).toBeDefined();
+    expect(noTailwindClasses.meta.type).toBe('problem');
+    expect(noTailwindClasses.meta.docs).toBeDefined();
+    expect(noTailwindClasses.meta.docs.description).toBe(
+      'Reports Tailwind classes that conflict with Elements styling. Strict mode reports any Tailwind-shaped class.'
+    );
+    expect(noTailwindClasses.meta.docs.category).toBe('Best Practice');
+    expect(noTailwindClasses.meta.docs.recommended).toBe(true);
+    expect(noTailwindClasses.meta.docs.url).toContain('/docs/lint/');
+    expect(noTailwindClasses.meta.schema).toBeDefined();
+    expect(noTailwindClasses.meta.messages).toBeDefined();
+    expect(noTailwindClasses.meta.messages['no-tailwind-class']).toBe(
+      'Unexpected Tailwind class "{{tailwindClass}}" on <{{tagName}}>. Use Elements global attributes (nve-layout, nve-text, nve-display) or Elements components instead.'
+    );
+    expect(noTailwindClasses.meta.messages['no-tailwind-class-with-suggestion']).toBe(
+      'Unexpected Tailwind class "{{tailwindClass}}" on <{{tagName}}>. Use {{suggestion}} instead.'
+    );
+    expect(noTailwindClasses.meta.messages['no-tailwind-class-on-nve-element']).toBe(
+      'Unexpected Tailwind class "{{tailwindClass}}" on <{{tagName}}>. nve-* components do not support Tailwind utilities — use component-specific APIs instead.'
+    );
+  });
+
+  it('should allow elements without a class attribute', () => {
+    tester.run('should allow elements without a class attribute', rule, {
+      valid: [
+        '<div></div>',
+        '<nve-button>Button</nve-button>',
+        '<nve-icon name="check"></nve-icon>',
+        '<div id="foo" data-test="bar"></div>'
+      ],
+      invalid: []
+    });
+  });
+
+  it('should allow empty or whitespace-only class values', () => {
+    tester.run('should allow empty or whitespace-only class values', rule, {
+      valid: ['<div class=""></div>', '<div class="   "></div>', '<div class></div>'],
+      invalid: []
+    });
+  });
+
+  it('should allow custom non-Tailwind class names', () => {
+    tester.run('should allow custom non-Tailwind class names', rule, {
+      valid: [
+        '<div class="my-card"></div>',
+        '<div class="card title__primary"></div>',
+        '<div class="container"></div>',
+        '<nve-card class="theme-dark"></nve-card>',
+        '<section class="hero hero--large hero__title"></section>'
+      ],
+      invalid: []
+    });
+  });
+
+  it('should allow class values with template bindings', () => {
+    tester.run('should allow class values with template bindings', rule, {
+      valid: [
+        '<div class="${cls}"></div>',
+        '<div class="{{cls}}"></div>',
+        '<div class="{cls}"></div>',
+        '<div class="{% if active %}active{% endif %}"></div>',
+        '<div class="card ${dynamic}"></div>'
+      ],
+      invalid: []
+    });
+  });
+
+  it('should report static Tailwind tokens on nve-* elements in class values with template bindings', () => {
+    tester.run('should report static Tailwind tokens on nve-* elements in class values with template bindings', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<nve-card class="p-4 ${dynamic}"></nve-card>',
+          errors: [
+            {
+              messageId: 'no-tailwind-class-on-nve-element',
+              data: { tailwindClass: 'p-4', tagName: 'nve-card' }
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('should allow markdown-frontmatter wrapped content', () => {
+    tester.run('should allow markdown-frontmatter wrapped content', rule, {
+      valid: ['---\ntitle: Test\n---\n<div class="my-card"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should allow standalone Tailwind keywords on non-nve elements by default', () => {
+    tester.run('should allow standalone Tailwind keywords on non-nve elements by default', rule, {
+      valid: ['<div class="truncate"></div>', '<div class="flex"></div>', '<div class="hidden"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should allow Tailwind tokens matching the prefix regex on non-nve elements by default', () => {
+    tester.run('should allow Tailwind tokens matching the prefix regex on non-nve elements by default', rule, {
+      valid: ['<div class="p-4"></div>', '<div class="bg-red-500"></div>', '<div class="text-xl"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should ignore tokens with arbitrary bracket values when no hint exists', () => {
+    tester.run('should ignore tokens with arbitrary bracket values when no hint exists', rule, {
+      valid: ['<div class="bg-[#ff0000]"></div>', '<div class="w-[123px]"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should allow tokens with variant prefixes on non-nve elements by default', () => {
+    tester.run('should allow tokens with variant prefixes on non-nve elements by default', rule, {
+      valid: [
+        '<div class="hover:bg-red-500"></div>',
+        '<div class="dark:hover:bg-red-500"></div>',
+        '<div class="md:flex"></div>'
+      ],
+      invalid: []
+    });
+  });
+
+  it('should ignore tokens with the important modifier when no hint exists', () => {
+    tester.run('should ignore tokens with the important modifier when no hint exists', rule, {
+      valid: ['<div class="!p-4"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should ignore negative spacing tokens when no hint exists', () => {
+    tester.run('should ignore negative spacing tokens when no hint exists', rule, {
+      valid: ['<div class="-mx-4"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should allow Tailwind tokens mixed with custom classes on non-nve elements by default', () => {
+    tester.run('should allow Tailwind tokens mixed with custom classes on non-nve elements by default', rule, {
+      valid: ['<div class="my-card flex p-4"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should allow class values containing newlines on non-nve elements by default', () => {
+    tester.run('should allow class values containing newlines on non-nve elements by default', rule, {
+      valid: ['<div class="flex\n  p-4"></div>'],
+      invalid: []
+    });
+  });
+
+  it('should ignore non-class attributes that contain Tailwind-like values', () => {
+    tester.run('should ignore non-class attributes that contain Tailwind-like values', rule, {
+      valid: ['<div id="flex"></div>', '<div data-test="p-4"></div>', '<div title="Use flex layout"></div>'],
+      invalid: []
+    });
+  });
+
+  describe('with { strict: true }', () => {
+    const strictOptions = [{ strict: true }];
+
+    it('should report any Tailwind class even without a known alternative', () => {
+      tester.run('should report any Tailwind class even without a known alternative', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: '<div class="truncate"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: 'truncate', tagName: 'div' } }]
+          },
+          {
+            code: '<div class="p-4"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: 'p-4', tagName: 'div' } }]
+          },
+          {
+            code: '<div class="bg-red-500"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: 'bg-red-500', tagName: 'div' } }]
+          }
+        ]
+      });
+    });
+
+    it('should still prefer the suggestion message when a hint exists', () => {
+      tester.run('should still prefer the suggestion message when a hint exists', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: '<div class="flex"></div>',
+            options: strictOptions,
+            errors: [
+              {
+                messageId: 'no-tailwind-class-with-suggestion',
+                data: { tailwindClass: 'flex', tagName: 'div', suggestion: 'nve-layout="row"' }
+              }
+            ]
+          },
+          {
+            code: '<div class="hidden"></div>',
+            options: strictOptions,
+            errors: [
+              {
+                messageId: 'no-tailwind-class-with-suggestion',
+                data: { tailwindClass: 'hidden', tagName: 'div', suggestion: 'nve-display="hide"' }
+              }
+            ]
+          },
+          {
+            code: '<div class="text-xl"></div>',
+            options: strictOptions,
+            errors: [
+              {
+                messageId: 'no-tailwind-class-with-suggestion',
+                data: { tailwindClass: 'text-xl', tagName: 'div', suggestion: 'nve-text="xl"' }
+              }
+            ]
+          },
+          {
+            code: '<div class="md:flex"></div>',
+            options: strictOptions,
+            errors: [
+              {
+                messageId: 'no-tailwind-class-with-suggestion',
+                data: { tailwindClass: 'md:flex', tagName: 'div', suggestion: 'nve-layout="row"' }
+              }
+            ]
+          },
+          {
+            code: '<div class="flex ${dynamic}"></div>',
+            options: strictOptions,
+            errors: [
+              {
+                messageId: 'no-tailwind-class-with-suggestion',
+                data: { tailwindClass: 'flex', tagName: 'div', suggestion: 'nve-layout="row"' }
+              }
+            ]
+          }
+        ]
+      });
+    });
+
+    it('should report bracket, important, negative, and variant tokens', () => {
+      tester.run('should report bracket, important, negative, and variant tokens', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: '<div class="bg-[#ff0000]"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: 'bg-[#ff0000]', tagName: 'div' } }]
+          },
+          {
+            code: '<div class="w-[123px]"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: 'w-[123px]', tagName: 'div' } }]
+          },
+          {
+            code: '<div class="!p-4"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: '!p-4', tagName: 'div' } }]
+          },
+          {
+            code: '<div class="-mx-4"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: '-mx-4', tagName: 'div' } }]
+          },
+          {
+            code: '<div class="hover:bg-red-500"></div>',
+            options: strictOptions,
+            errors: [{ messageId: 'no-tailwind-class', data: { tailwindClass: 'hover:bg-red-500', tagName: 'div' } }]
+          },
+          {
+            code: '<div class="dark:hover:bg-red-500"></div>',
+            options: strictOptions,
+            errors: [
+              {
+                messageId: 'no-tailwind-class',
+                data: { tailwindClass: 'dark:hover:bg-red-500', tagName: 'div' }
+              }
+            ]
+          }
+        ]
+      });
+    });
+
+    it('should report mixed hinted and unhinted Tailwind tokens together', () => {
+      tester.run('should report mixed hinted and unhinted Tailwind tokens together', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: '<div class="my-card flex p-4"></div>',
+            options: strictOptions,
+            errors: [
+              {
+                messageId: 'no-tailwind-class-with-suggestion',
+                data: { tailwindClass: 'flex', tagName: 'div', suggestion: 'nve-layout="row"' }
+              },
+              { messageId: 'no-tailwind-class', data: { tailwindClass: 'p-4', tagName: 'div' } }
+            ]
+          }
+        ]
+      });
+    });
+  });
+
+  describe('tailwind classes on nve-* elements', () => {
+    it('should report Tailwind classes that style nve-* element surfaces or internals', () => {
+      tester.run('should report Tailwind classes that style nve-* element surfaces or internals', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: '<nve-card class="p-4"></nve-card>',
+            errors: [
+              { messageId: 'no-tailwind-class-on-nve-element', data: { tailwindClass: 'p-4', tagName: 'nve-card' } }
+            ]
+          },
+          {
+            code: '<nve-card class="bg-red-500"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'bg-red-500', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="rounded-lg"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'rounded-lg', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-button class="text-xl"></nve-button>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'text-xl', tagName: 'nve-button' }
+              }
+            ]
+          },
+          {
+            code: '<nve-button class="text-base"></nve-button>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'text-base', tagName: 'nve-button' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="border"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'border', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="shadow-md"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'shadow-md', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="px-4"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'px-4', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="flex"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'flex', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="items-center"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'items-center', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="justify-center"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'justify-center', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="grid-cols-3"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'grid-cols-3', tagName: 'nve-card' }
+              }
+            ]
+          }
+        ]
+      });
+    });
+
+    it('should allow host-level Tailwind utilities on nve-* elements', () => {
+      tester.run('should allow host-level Tailwind utilities on nve-* elements', rule, {
+        valid: [
+          '<nve-card class="hidden"></nve-card>',
+          '<nve-card class="visible"></nve-card>',
+          '<nve-card class="invisible"></nve-card>',
+          '<nve-card class="sr-only"></nve-card>',
+          '<nve-card class="not-sr-only"></nve-card>',
+          '<nve-card class="absolute"></nve-card>',
+          '<nve-card class="sticky"></nve-card>',
+          '<nve-card class="top-4"></nve-card>',
+          '<nve-card class="z-10"></nve-card>',
+          '<nve-card class="mt-4"></nve-card>',
+          '<nve-card class="-mx-4"></nve-card>',
+          '<nve-card class="m-[10px]"></nve-card>',
+          '<nve-card class="self-center"></nve-card>',
+          '<nve-card class="basis-1/2"></nve-card>',
+          '<nve-card class="order-1"></nve-card>',
+          '<nve-card class="grow"></nve-card>',
+          '<nve-card class="shrink"></nve-card>'
+        ],
+        invalid: []
+      });
+    });
+
+    it('should handle variants, modifiers, and brackets on nve-* elements', () => {
+      tester.run('should handle variants, modifiers, and brackets on nve-* elements', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: '<nve-card class="!p-4"></nve-card>',
+            errors: [
+              { messageId: 'no-tailwind-class-on-nve-element', data: { tailwindClass: '!p-4', tagName: 'nve-card' } }
+            ]
+          },
+          {
+            code: '<nve-card class="hover:bg-red-500"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'hover:bg-red-500', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="md:flex"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'md:flex', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="w-[123px]"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'w-[123px]', tagName: 'nve-card' }
+              }
+            ]
+          }
+        ]
+      });
+    });
+
+    it('should allow host-level Tailwind utilities with variants, modifiers, and brackets on nve-* elements', () => {
+      tester.run(
+        'should allow host-level Tailwind utilities with variants, modifiers, and brackets on nve-* elements',
+        rule,
+        {
+          valid: [
+            '<nve-card class="md:absolute"></nve-card>',
+            '<nve-card class="!-mt-4"></nve-card>',
+            '<nve-card class="md:self-center"></nve-card>',
+            '<nve-card class="hover:m-[10px]"></nve-card>'
+          ],
+          invalid: []
+        }
+      );
+    });
+
+    it('should not flag non-Tailwind custom classes on nve-* elements', () => {
+      tester.run('should not flag non-Tailwind custom classes on nve-* elements', rule, {
+        valid: [
+          '<nve-card class="theme-dark"></nve-card>',
+          '<nve-card class="my-card"></nve-card>',
+          '<nve-card class="p-section"></nve-card>',
+          '<nve-card class="flex-container"></nve-card>',
+          '<nve-card class="card hero__title"></nve-card>'
+        ],
+        invalid: []
+      });
+    });
+
+    it('should report only invalid Tailwind tokens in a mixed class list on nve-* elements', () => {
+      tester.run('should report only invalid Tailwind tokens in a mixed class list on nve-* elements', rule, {
+        valid: [],
+        invalid: [
+          {
+            code: '<nve-card class="my-card sticky flex mt-4 p-4 bg-red-500 self-center"></nve-card>',
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'flex', tagName: 'nve-card' }
+              },
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'p-4', tagName: 'nve-card' }
+              },
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'bg-red-500', tagName: 'nve-card' }
+              }
+            ]
+          }
+        ]
+      });
+    });
+
+    it('should only allow host-level Tailwind utilities on nve-* elements outside strict mode', () => {
+      tester.run('should only allow host-level Tailwind utilities on nve-* elements outside strict mode', rule, {
+        valid: [
+          {
+            code: '<nve-card class="hidden"></nve-card>',
+            options: [{ strict: false }]
+          },
+          {
+            code: '<nve-card class="m-4"></nve-card>',
+            options: [{ strict: false }]
+          }
+        ],
+        invalid: [
+          {
+            code: '<nve-card class="p-4"></nve-card>',
+            options: [{ strict: false }],
+            errors: [
+              { messageId: 'no-tailwind-class-on-nve-element', data: { tailwindClass: 'p-4', tagName: 'nve-card' } }
+            ]
+          },
+          {
+            code: '<nve-card class="p-4"></nve-card>',
+            options: [{ strict: true }],
+            errors: [
+              { messageId: 'no-tailwind-class-on-nve-element', data: { tailwindClass: 'p-4', tagName: 'nve-card' } }
+            ]
+          },
+          {
+            code: '<nve-card class="hidden"></nve-card>',
+            options: [{ strict: true }],
+            errors: [
+              {
+                messageId: 'no-tailwind-class-on-nve-element',
+                data: { tailwindClass: 'hidden', tagName: 'nve-card' }
+              }
+            ]
+          },
+          {
+            code: '<nve-card class="m-4"></nve-card>',
+            options: [{ strict: true }],
+            errors: [
+              { messageId: 'no-tailwind-class-on-nve-element', data: { tailwindClass: 'm-4', tagName: 'nve-card' } }
+            ]
+          }
+        ]
+      });
+    });
+  });
+});

--- a/projects/lint/src/eslint/rules/no-tailwind-classes.ts
+++ b/projects/lint/src/eslint/rules/no-tailwind-classes.ts
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Rule } from 'eslint';
+import { createVisitors } from '@html-eslint/eslint-plugin/lib/rules/utils/visitors.js';
+import { findAttr } from '@html-eslint/eslint-plugin/lib/rules/utils/node.js';
+import { VALUE_BINDINGS } from '../internals/attributes.js';
+import {
+  HINTS,
+  isAllowedNveHostTailwindToken,
+  isTailwindToken,
+  stripVariantsAndModifiers
+} from '../internals/tailwind.js';
+import type { HtmlAttribute, HtmlTagNode } from '../rule-types.js';
+
+declare const __ELEMENTS_PAGES_BASE_URL__: string;
+
+const rule = {
+  meta: {
+    type: 'problem' as const,
+    docs: {
+      description:
+        'Reports Tailwind classes that conflict with Elements styling. Strict mode reports any Tailwind-shaped class.',
+      category: 'Best Practice',
+      recommended: true,
+      url: `${__ELEMENTS_PAGES_BASE_URL__}/docs/lint/`
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          strict: {
+            type: 'boolean',
+            default: false,
+            description:
+              'When true, reports any Tailwind-shaped class on any element. When false, only reports problematic Tailwind classes on nve-* elements while allowing host-level visibility, positioning, margin, and flex-item utilities.'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      ['no-tailwind-class']:
+        'Unexpected Tailwind class "{{tailwindClass}}" on <{{tagName}}>. Use Elements global attributes (nve-layout, nve-text, nve-display) or Elements components instead.',
+      ['no-tailwind-class-with-suggestion']:
+        'Unexpected Tailwind class "{{tailwindClass}}" on <{{tagName}}>. Use {{suggestion}} instead.',
+      ['no-tailwind-class-on-nve-element']:
+        'Unexpected Tailwind class "{{tailwindClass}}" on <{{tagName}}>. nve-* components do not support Tailwind utilities — use component-specific APIs instead.'
+    }
+  },
+  create(context: Rule.RuleContext) {
+    const strict = (context.options[0] as { strict?: boolean } | undefined)?.strict === true;
+
+    function isDynamicToken(token: string) {
+      return VALUE_BINDINGS.some(binding => token.includes(binding));
+    }
+
+    function reportToken({
+      classAttr,
+      tagName,
+      token,
+      isNveTag
+    }: {
+      classAttr: HtmlAttribute;
+      tagName: string;
+      token: string;
+      isNveTag: boolean;
+    }) {
+      const bare = stripVariantsAndModifiers(token);
+      const suggestion = HINTS[bare];
+      const isKnownTailwindToken = Boolean(suggestion) || isTailwindToken(bare);
+
+      if (isNveTag) {
+        if (isKnownTailwindToken && (strict || !isAllowedNveHostTailwindToken(bare))) {
+          context.report({
+            node: classAttr,
+            messageId: 'no-tailwind-class-on-nve-element',
+            data: { tailwindClass: token, tagName }
+          });
+        }
+        return;
+      }
+
+      if (strict && suggestion) {
+        context.report({
+          node: classAttr,
+          messageId: 'no-tailwind-class-with-suggestion',
+          data: { tailwindClass: token, tagName, suggestion }
+        });
+        return;
+      }
+
+      if (strict && isKnownTailwindToken) {
+        context.report({
+          node: classAttr,
+          messageId: 'no-tailwind-class',
+          data: { tailwindClass: token, tagName }
+        });
+      }
+    }
+
+    return createVisitors(context, {
+      Tag(node: HtmlTagNode) {
+        const classAttr = findAttr(node, 'class');
+        if (!classAttr) return;
+
+        const value = classAttr.value?.value ?? '';
+        if (!value.trim()) return;
+
+        const isNveTag = node.name?.toLowerCase().startsWith('nve-') ?? false;
+        const tagName = node.name;
+
+        for (const token of value.split(/\s+/).filter(Boolean)) {
+          if (isDynamicToken(token)) continue;
+          reportToken({ classAttr, tagName, token, isNveTag });
+        }
+      }
+    });
+  }
+} as const;
+
+export default rule;

--- a/projects/site/src/docs/lint/index.md
+++ b/projects/site/src/docs/lint/index.md
@@ -206,6 +206,18 @@ export default [
     <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
   </nve-grid-row>
   <nve-grid-row>
+    <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-slotted-popovers</code></nve-grid-cell>
+    <nve-grid-cell>Disallow the slot attribute on popover elements (nve-tooltip, nve-dialog, nve-drawer, ...).</nve-grid-cell>
+    <nve-grid-cell>HTML</nve-grid-cell>
+    <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
+  </nve-grid-row>
+  <nve-grid-row>
+    <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-tailwind-classes</code></nve-grid-cell>
+    <nve-grid-cell>Disallow Tailwind CSS utility classes with Elements alternatives, and all Tailwind utilities on nve custom elements.</nve-grid-cell>
+    <nve-grid-cell>HTML</nve-grid-cell>
+    <nve-grid-cell><code nve-text="code">warn</code></nve-grid-cell>
+  </nve-grid-row>
+  <nve-grid-row>
     <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-unexpected-attribute-value</code></nve-grid-cell>
     <nve-grid-cell>Disallow use of invalid attribute values for nve-* elements.</nve-grid-cell>
     <nve-grid-cell>HTML</nve-grid-cell>


### PR DESCRIPTION
- `no-slotted-popovers` to prevent the use of the slot attribute on popover elements
- `no-tailwind-classes` to disallow Tailwind CSS utility classes on nve custom elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two linting rules for HTML: one targeting popover slot usage and one detecting Tailwind-like classes.

* **Documentation**
  * Updated lint docs and site listing for the two new rules.

* **Tests**
  * Added comprehensive test suites validating the new lint rules' behavior.

* **Bug Fixes**
  * Adjusted the Interaction Drawer example markup to change its slot configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->