### PR TITLE
chore(ci): add labeler and stale workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,111 @@
+'dependencies':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/package.json'
+          - 'pnpm-lock.yaml'
+          - 'pnpm-workspace.yaml'
+
+'github_actions':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/actions/**'
+          - '.github/dependabot.yml'
+          - '.github/workflows/**'
+
+'scope(ci)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'commitlint.config.js'
+          - 'config/**'
+          - 'package.json'
+          - 'pnpm-lock.yaml'
+          - 'release.config.js'
+          - 'projects/internals/ci/**'
+
+'scope(cli)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/cli/**'
+
+'scope(code)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/code/**'
+
+'scope(core)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/core/**'
+
+'scope(create)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/create/**'
+
+'scope(docs)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/site/**'
+
+'scope(forms)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/forms/**'
+
+'scope(internals)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/internals/**'
+
+'scope(lint)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/lint/**'
+
+'scope(markdown)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/markdown/**'
+
+'scope(media)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/media/**'
+
+'scope(monaco)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/monaco/**'
+
+'scope(pages)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/pages/**'
+
+'scope(starters)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/starters/**'
+
+'scope(styles)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/styles/**'
+
+'scope(themes)':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'projects/themes/**'
+
+'type(chore)':
+  - head-branch:
+      - '^chore[/-]'
+
+'type(feat)':
+  - head-branch:
+      - '^feat[/-]'
+
+'type(fix)':
+  - head-branch:
+      - '^fix[/-]'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,20 @@
+name: Label
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
+        with:
+          sync-labels: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: stale-workflow
+  cancel-in-progress: true
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+        with:
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: This issue has had no activity for 90 days. Comment or remove the stale label if it is still actionable; otherwise it will close in 14 days.
+          stale-pr-message: This pull request has had no activity for 30 days. Comment or remove the stale label when it is ready for review.
+          close-issue-message: Closing because this issue stayed stale for 14 days with no activity.
+          days-before-issue-stale: 90
+          days-before-pr-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-close: -1
+          close-issue-reason: not_planned
+          exempt-all-assignees: true
+          exempt-draft-pr: true
+          operations-per-run: 100


### PR DESCRIPTION
- Introduced a labeler configuration to automate labeling based on file changes.
- Added a stale workflow to manage inactive issues and pull requests, including customizable messages and timing for stale checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated PR labeling now applies scope/type labels based on changed files and branch names and runs automatically on pull request events.
  * New scheduled/manual workflow marks inactive issues and PRs as stale daily; issues are closed after 14 days of staleness while PRs are exempt from automatic closing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/elements/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->