### PR TITLE
fix(cli): broken default binary path

### DIFF
--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -19,9 +19,9 @@
     "directory": "projects/cli"
   },
   "sideEffects": false,
+  "mcpName": "io.github.nvidia/elements",
   "bin": {
-    "nve": "./dist/index.js",
-    "nve-mcp": "./dist/mcp/index.js"
+    "nve": "./dist/index.js"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI package metadata for Model Context Protocol integration
  * Removed the `nve-mcp` executable; only the `nve` command is now available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/elements/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->