### PR TITLE
fix(docs): iframe example paths

### DIFF
--- a/projects/site/package.json
+++ b/projects/site/package.json
@@ -201,7 +201,7 @@
       ]
     },
     "test": {
-      "command": "vitest run src/_11ty/layouts/metadata.test.ts src/_11ty/layouts/links.test.ts src/_11ty/transforms/site-urls.test.ts src/_11ty/shortcodes/api.test.ts src/_11ty/plugins/llms-txt.test.ts src/_11ty/plugins/sitemap-xml.test.ts src/docs/metrics/api-status.test.ts",
+      "command": "vitest run src/_11ty/layouts/metadata.test.ts src/_11ty/layouts/links.test.ts src/_11ty/transforms/site-urls.test.ts src/_11ty/shortcodes/api.test.ts src/_11ty/shortcodes/example.test.ts src/_11ty/plugins/llms-txt.test.ts src/_11ty/plugins/sitemap-xml.test.ts src/docs/metrics/api-status.test.ts src/examples/index.test.ts",
       "files": [
         "src/**/*.js",
         "src/**/*.md",

--- a/projects/site/src/_11ty/shortcodes/example.js
+++ b/projects/site/src/_11ty/shortcodes/example.js
@@ -66,7 +66,7 @@ export async function exampleShortcode(
   const templateContent = example?.template.replace(/\n\n/g, '\n');
   const reload = globalThis.process.env.ELEVENTY_RUN_MODE === 'serve' ? reloadScript(example, canvasId) : '';
   const inlineTemplate = /* html */ `<div id="${canvasId}_content">${templateContent}</div>${reload}`;
-  const iframeTemplate = /* html */ `<iframe loading="lazy" src="examples/${example?.permalink}index.html" style="height: 100%; width: 100%; border: none;"></iframe>`;
+  const iframeTemplate = /* html */ `<iframe loading="lazy" src="/examples/${example?.permalink}index.html" style="height: 100%; width: 100%; border: none;"></iframe>`;
   const template = config.inline ? inlineTemplate : iframeTemplate;
   const summary = markdown
     .render(example.description || example.summary || '')

--- a/projects/site/src/_11ty/shortcodes/example.test.ts
+++ b/projects/site/src/_11ty/shortcodes/example.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const patternExample = {
+  id: 'pattern-chat-popover-chat',
+  name: 'PopoverChat',
+  template: '<nve-dialog></nve-dialog>',
+  summary: 'Bottom-right anchored chat dialog with launcher button.',
+  description: '',
+  tags: ['pattern'],
+  entrypoint: '@internals/patterns/chat.examples.json',
+  element: 'nve-patterns',
+  elementName: 'patterns',
+  permalink: '@internals/patterns/chat-pattern-chat-popover-chat/'
+};
+
+async function importShortcode() {
+  vi.resetModules();
+  vi.doMock('../../index.11tydata.js', () => ({
+    siteData: {
+      examples: [patternExample]
+    }
+  }));
+  vi.doMock('@internals/tools/playground', () => ({
+    PlaygroundService: {
+      create: vi.fn().mockResolvedValue('')
+    }
+  }));
+
+  return import('./example.js');
+}
+
+afterEach(() => {
+  vi.doUnmock('../../index.11tydata.js');
+  vi.doUnmock('@internals/tools/playground');
+});
+
+describe('exampleShortcode', () => {
+  it('should render iframe examples from the root examples route', async () => {
+    const { exampleShortcode } = await importShortcode();
+
+    const html = await exampleShortcode('@internals/patterns/chat.examples.json', 'PopoverChat', {
+      inline: false
+    });
+
+    expect(html).toContain('src="/examples/@internals/patterns/chat-pattern-chat-popover-chat/index.html"');
+    expect(html).not.toContain('/docs/patterns/chat/examples/');
+  });
+});

--- a/projects/site/src/examples/index.11ty.js
+++ b/projects/site/src/examples/index.11ty.js
@@ -20,8 +20,31 @@ function escapeAttr(value) {
     .replace(/'/g, '&#39;');
 }
 
-function getCanonicalUrl(example) {
-  const path = example.elementName ? `/docs/elements/${example.elementName}/examples/` : '/examples/';
+function getPatternName(example) {
+  return example.entrypoint?.match(/^@internals\/patterns\/([^/]+)\.examples\.json$/)?.[1] ?? null;
+}
+
+export function getCanonicalPath(example) {
+  const patternName = getPatternName(example);
+
+  if (patternName) return `/docs/patterns/${patternName}/`;
+  if (example.elementName) return `/docs/elements/${example.elementName}/examples/`;
+
+  return '/examples/';
+}
+
+export function getDocumentationPath(example) {
+  const patternName = getPatternName(example);
+
+  if (patternName) return `/docs/patterns/${patternName}/`;
+  if (example.elementName) return `/docs/elements/${example.elementName}/`;
+
+  return '/examples/';
+}
+
+export function getCanonicalUrl(example) {
+  const path = getCanonicalPath(example);
+
   return `${SITE_ORIGIN}${PATH_PREFIX}${path}`;
 }
 
@@ -67,7 +90,7 @@ export async function render(data) {
   <body data-pagefind-ignore="all">
     <div id="iframe-links" nve-layout="row gap:sm align:right" hidden>
       <a href="${await PlaygroundService.create({ template: data.example.template, name: data.example.id })}" target="_blank" nve-text="link body sm">playground &#8599;</a>
-      <a href="/docs/elements/${data.example.elementName}/" target="_blank" nve-text="link body sm">documentation &#8599;</a>
+      <a href="${getDocumentationPath(data.example)}" target="_blank" nve-text="link body sm">documentation &#8599;</a>
     </div>
     <div id="example-container" data-element="${data.example.id}">
       ${data.example.template}

--- a/projects/site/src/examples/index.test.ts
+++ b/projects/site/src/examples/index.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+interface Example {
+  elementName?: string;
+  entrypoint?: string;
+}
+
+async function importExamplePage() {
+  vi.resetModules();
+  vi.stubEnv('ELEMENTS_SITE_URL', 'https://nvidia.github.io');
+  vi.stubEnv('PAGES_BASE_URL', '/elements/');
+  vi.doMock('../index.11tydata.js', () => ({
+    siteData: {
+      BASE_URL: '/elements/',
+      examples: []
+    }
+  }));
+  vi.doMock('@internals/tools/playground', () => ({
+    PlaygroundService: {
+      create: vi.fn().mockResolvedValue('')
+    }
+  }));
+
+  return import('./index.11ty.js');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.doUnmock('../index.11tydata.js');
+  vi.doUnmock('@internals/tools/playground');
+});
+
+describe('example page urls', () => {
+  it('should point pattern examples at pattern documentation', async () => {
+    const { getCanonicalPath, getCanonicalUrl, getDocumentationPath } = await importExamplePage();
+    const example: Example = {
+      elementName: 'patterns',
+      entrypoint: '@internals/patterns/subheader.examples.json'
+    };
+
+    expect(getCanonicalPath(example)).toBe('/docs/patterns/subheader/');
+    expect(getDocumentationPath(example)).toBe('/docs/patterns/subheader/');
+    expect(getCanonicalUrl(example)).toBe('https://nvidia.github.io/elements/docs/patterns/subheader/');
+  });
+
+  it('should keep component examples pointed at component documentation', async () => {
+    const { getCanonicalPath, getDocumentationPath } = await importExamplePage();
+    const example: Example = {
+      elementName: 'button',
+      entrypoint: '@nvidia-elements/core/button/button.examples.json'
+    };
+
+    expect(getCanonicalPath(example)).toBe('/docs/elements/button/examples/');
+    expect(getDocumentationPath(example)).toBe('/docs/elements/button/');
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed example iframe loading to use absolute paths, ensuring proper resolution across the site.
  * Corrected documentation routing for pattern examples to point to appropriate pattern documentation instead of element documentation.

* **Tests**
  * Expanded test coverage for example page routing and iframe rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->