### PR TITLE
chore(docs): document cursor cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,3 +273,25 @@ When adding new technical terms, component names, or abbreviations that Vale fla
 - `projects/*/DEVELOPMENT.md` - When working within a specific project; lists all available pnpm scripts for that project
 - `/projects/internals/BUILD.md` - When modifying build configuration, Wireit scripts, or CI/CD pipeline
 - `/projects/internals/RELEASE.md` - When creating new projects or modifying release process; covers semantic release setup, CI artifacts, commit scopes, initial tags
+
+## Cursor Cloud specific instructions
+
+These notes are for cloud agents running in the prebuilt VM (dependencies already installed by the startup update script). They capture non-obvious caveats, not full setup steps.
+
+### Toolchain access
+
+- **mise** manages the toolchain, and the VM image already includes it. `~/.local/bin` sits on `PATH` and `mise activate` runs from `~/.bashrc`, so `node` (26.4.0), `pnpm` (11.9.0), `go`, `vale`, and `git-lfs` resolve directly. If a fresh shell ever lacks them, prefix commands with `mise exec --` (for example, `mise exec -- pnpm ...`) or run `mise run <task>`.
+- Run all repo commands through mise to guarantee the pinned versions, exactly as the root `AGENTS.md` examples show.
+
+### Network restrictions (important gotcha)
+
+- Outbound network access has restrictions. The firewall blocks `nodejs.org`, so `mise install` cannot fetch Node from the official mirror. The setup pre-seeds Node 26.4.0 into the mise install dir from the npm package `node-linux-x64@26.4.0` (the npm registry stays reachable). If the Node toolchain ever goes missing, reinstall it from that npm package rather than expecting `mise install` to download Node.
+- Reachable hosts include `registry.npmjs.org`, `github.com`, `*.githubusercontent.com`, `dl.google.com`, and `cdn.playwright.dev` (Playwright Chromium downloads work). `git lfs pull` may fail or stall; LFS assets only matter for visual-regression baselines, not for running the site or unit tests.
+
+### Running the docs site (primary app)
+
+- The documentation site (`projects/site`, Eleventy) is the main runnable application and renders every component. Start it with `cd projects/site && pnpm run dev`; Wireit first builds the `themes` → `styles` → `forms` → `core` dependencies, then serves at **http://localhost:8082/elements/**. Component pages live under `/elements/docs/elements/<name>/` (for example, `.../switch/`, `.../accordion/`).
+
+### Testing caveat
+
+- Unit tests run in **browser mode** (Vitest + Playwright Chromium). Wireit caches `pnpm run test` results by input files, so a cached run reports "skipped" without actually executing. To force a real run of a single suite, run Vitest directly, for example `cd projects/core && pnpm exec vitest run src/badge/badge.test.ts`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cloud Agent development environment for the Elements monorepo, and records durable, non-obvious caveats for future agents in `AGENTS.md` under `## Cursor Cloud specific instructions`.

No application/source code was changed. The only committed change is documentation in `AGENTS.md` (which `CLAUDE.md` symlinks to).

## Environment setup performed

- Installed **mise** (downloaded the binary from GitHub releases because `mise.run` is firewalled).
- Installed the pinned toolchain via mise: `go 1.26.4`, `pnpm 11.9.0`, `vale 3.15.1`, `git-lfs 3.7.1`.
- `nodejs.org` is firewalled, so `mise install` cannot fetch Node. Seeded **Node 26.4.0** into the mise install dir from the npm package `node-linux-x64@26.4.0` (npm registry is reachable).
- Ran `pnpm install --frozen-lockfile` (also installed Playwright Chromium via `cdn.playwright.dev`).

## Verification

- Built dependencies and ran the docs site (`projects/site`, Eleventy) at `http://localhost:8082/elements/` and interacted with live components (toggled `nve-switch`, expanded an accordion).
- `cd projects/core && pnpm exec vitest run src/badge/badge.test.ts` → 27/27 passed (browser-mode Chromium).
- `cd projects/core && pnpm exec eslint src/badge/` → clean.

## Demo

[elements_docs_site_demo.mp4](https://cursor.com/agents/bc-2899a868-fa41-42f4-9d5b-2ca5fb984bf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felements_docs_site_demo.mp4)

[Switch toggled on](https://cursor.com/agents/bc-2899a868-fa41-42f4-9d5b-2ca5fb984bf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswitch_toggled_on.webp)
[Accordion expanded](https://cursor.com/agents/bc-2899a868-fa41-42f4-9d5b-2ca5fb984bf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccordion_expanded.webp)

## Update script (startup)

```
~/.local/bin/mise install
~/.local/bin/mise exec -- git lfs install --skip-repo
~/.local/bin/mise exec -- pnpm install --frozen-lockfile --prefer-offline
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2899a868-fa41-42f4-9d5b-2ca5fb984bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2899a868-fa41-42f4-9d5b-2ca5fb984bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

