### PR TITLE
fix(cli): correct case sensitive identifiers

### DIFF
--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -19,7 +19,7 @@
     "directory": "projects/cli"
   },
   "sideEffects": false,
-  "mcpName": "io.github.nvidia/elements",
+  "mcpName": "io.github.NVIDIA/elements",
   "bin": {
     "nve": "./dist/index.js"
   },

--- a/projects/cli/server.json
+++ b/projects/cli/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.nvidia/elements",
+  "name": "io.github.NVIDIA/elements",
   "title": "NVIDIA Elements",
   "description": "NVIDIA Elements UI design system and agent tools for AI/ML, robotics, and autonomous vehicles.",
   "websiteUrl": "https://nvidia.github.io/elements/docs/mcp/",

--- a/projects/cli/src/mcp/index.ts
+++ b/projects/cli/src/mcp/index.ts
@@ -102,7 +102,7 @@ export async function startMcpServer() {
   process.env.ELEMENTS_ENV = 'mcp';
 
   const server = new McpServer({
-    name: 'io.github.nvidia/elements',
+    name: 'io.github.NVIDIA/elements',
     version: VERSION,
     description:
       'NVIDIA Elements UI Design System (nve-*), custom element schemas, APIs and examples. Use the "elements" skill for more guidance if available.'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the CLI/MCP server identifier to use the correct `io.github.NVIDIA/elements` casing.
  * Kept the server’s behavior unchanged while making its displayed name consistent across configuration and startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->