### PR TITLE
fix(internals): add url length validation for url generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: projects/pages/dist
+          include-hidden-files: true
 
   lighthouse:
     runs-on: ubuntu-latest

--- a/projects/internals/tools/src/playground/service.test.ts
+++ b/projects/internals/tools/src/playground/service.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadTools, type ToolMethod, type ToolOutput } from '../internal/tools.js';
 import { PlaygroundService } from './service.js';
-import { createPlaygroundURL } from './utils.js';
+import { createPlaygroundURL, MAX_PLAYGROUND_URL_LENGTH } from './utils.js';
 
 // when ELEMENTS_PLAYGROUND_BASE_URL is not configured, createPlaygroundURL returns ''
 const hasPlaygroundBaseURL = createPlaygroundURL('test', []).length > 0;
@@ -146,6 +146,30 @@ describe('PlaygroundService', () => {
       expect(result.result?.[0]?.message).toContain(
         'Unexpected use of restricted attribute "nve-layout" on <nve-button>. Remove the attribute.'
       );
+    });
+
+    it('should handle content that would exceed the supported playground URL length', async () => {
+      process.env.ELEMENTS_ENV = 'browser';
+      const tools = loadTools(PlaygroundService);
+      const createTool = tools.find(tool => tool.metadata.name === 'create');
+
+      const result = (await createTool?.({
+        template: '<nve-button>valid</nve-button>',
+        name: 'x'.repeat(MAX_PLAYGROUND_URL_LENGTH),
+        start: false
+      })) as ToolOutput<string>;
+
+      if (!hasPlaygroundBaseURL) {
+        expect(result.status).toBe('complete');
+        expect(result.result).toBe('');
+        return;
+      }
+
+      expect(result.status).toBe('error');
+      expect(result.message).toBe(
+        `Playground content produces a URL that exceeds the ${MAX_PLAYGROUND_URL_LENGTH}-character limit.`
+      );
+      expect(result.result).toBeUndefined();
     });
 
     it('should skip validation and return URL when not in mcp or cli environment', async () => {

--- a/projects/internals/tools/src/playground/utils.test.ts
+++ b/projects/internals/tools/src/playground/utils.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { ProjectElement } from '@internals/metadata';
+import { ToolError } from '../internal/tools.js';
 import {
   createPlaygroundURL,
   createAngularFiles,
@@ -12,6 +13,7 @@ import {
   createVueFiles,
   createDefaultFiles,
   formatTemplate,
+  MAX_PLAYGROUND_URL_LENGTH,
   playgroundTypes
 } from './utils.js';
 
@@ -24,6 +26,20 @@ function expectURL(result: string, expected: string) {
   } else {
     expect(result).toBe('');
   }
+}
+
+function createDeterministicPseudorandomBytes(length: number) {
+  const bytes = new Uint8Array(length);
+  let state = 0x12345678;
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    bytes[index] = state;
+  }
+
+  return bytes;
 }
 
 describe('createPlaygroundURL', () => {
@@ -558,16 +574,38 @@ describe('createImportMap with different frameworks', () => {
 
 describe('serialize function behavior', () => {
   it('should compress and encode data by default', () => {
-    // The serialize function is called internally, so we test its effect
     const result = createPlaygroundURL('<nve-button></nve-button>', [], {});
 
     if (hasPlaygroundBaseURL) {
-      // Should contain encoded files data
       expect(result).toContain('&files=');
       expect(result.length).toBeGreaterThan(100); // Should be reasonably long due to compression
     } else {
       expect(result).toBe('');
     }
+  });
+
+  it('should reject playground URLs that exceed the supported V8 argument-count limit', () => {
+    const bytes = createDeterministicPseudorandomBytes(200_000);
+    const attributeValue = Buffer.from(bytes).toString('base64').replace(/[+/=]/g, 'A');
+    const template = `<div data-value="${attributeValue}">content</div>`;
+
+    if (!hasPlaygroundBaseURL) {
+      expect(createPlaygroundURL(template, [])).toBe('');
+      return;
+    }
+
+    let thrown: unknown;
+    try {
+      createPlaygroundURL(template, []);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ToolError);
+    expect(thrown).toHaveProperty(
+      'message',
+      `Playground content produces a URL that exceeds the ${MAX_PLAYGROUND_URL_LENGTH}-character limit.`
+    );
   });
 });
 

--- a/projects/internals/tools/src/playground/utils.ts
+++ b/projects/internals/tools/src/playground/utils.ts
@@ -4,6 +4,7 @@
 import { gzipSync } from 'fflate';
 import format from 'html-format';
 import type { Element } from '@internals/metadata';
+import { ToolError } from '../internal/tools.js';
 import { getElementImports } from '../internal/utils.js';
 import { validateTemplate } from '../internal/validate.js';
 
@@ -11,6 +12,7 @@ declare const __ELEMENTS_ESM_CDN_BASE_URL__: string;
 
 const ELEMENTS_PLAYGROUND_BASE_URL = process.env.ELEMENTS_PLAYGROUND_BASE_URL ?? '';
 const ELEMENTS_ESM_CDN_BASE_URL = __ELEMENTS_ESM_CDN_BASE_URL__;
+export const MAX_PLAYGROUND_URL_LENGTH = 32_768;
 
 interface PlaygroundOptions {
   type?: PlaygroundType;
@@ -147,12 +149,22 @@ export function createVueFiles(content: string, elements: Element[], options: Pl
 }
 
 function createURL(files: string, options: PlaygroundOptions) {
+  if (ELEMENTS_PLAYGROUND_BASE_URL.length === 0) {
+    return '';
+  }
+
   const defaultOptions = { openFile: 'index.html', ...options };
-  return ELEMENTS_PLAYGROUND_BASE_URL.length > 0
-    ? encodeURI(
-        `${ELEMENTS_PLAYGROUND_BASE_URL}/?version=1&layout=vertical-split${defaultOptions.name ? `&name=${defaultOptions.name.trim()}` : ''}${defaultOptions.theme ? `&theme=${defaultOptions.theme}` : ''}&file=${defaultOptions.openFile}${defaultOptions.referer ? `&ref=${defaultOptions.referer}` : ''}&files=${files}`
-      )
-    : '';
+  const url = encodeURI(
+    `${ELEMENTS_PLAYGROUND_BASE_URL}/?version=1&layout=vertical-split${defaultOptions.name ? `&name=${defaultOptions.name.trim()}` : ''}${defaultOptions.theme ? `&theme=${defaultOptions.theme}` : ''}&file=${defaultOptions.openFile}${defaultOptions.referer ? `&ref=${defaultOptions.referer}` : ''}&files=${files}`
+  );
+
+  if (url.length > MAX_PLAYGROUND_URL_LENGTH) {
+    throw new ToolError(
+      `Playground content produces a URL that exceeds the ${MAX_PLAYGROUND_URL_LENGTH}-character limit.`
+    );
+  }
+
+  return url;
 }
 
 function createLayoutStyles() {
@@ -195,8 +207,15 @@ nve-logo.large {
 function serialize(data: Record<string, { content: string }>, compress = true) {
   const encoded = new TextEncoder().encode(JSON.stringify(data));
   const array = compress ? gzipSync(encoded) : encoded;
-  const base64 = globalThis.btoa(String.fromCharCode(...array));
-  return encodeURIComponent(base64);
+  // Limit each function call to 32,768 arguments, safely below engine limits.
+  const chunkSize = 0x8000;
+  let binary = '';
+
+  for (let offset = 0; offset < array.length; offset += chunkSize) {
+    binary += String.fromCharCode(...array.subarray(offset, offset + chunkSize));
+  }
+
+  return encodeURIComponent(globalThis.btoa(binary));
 }
 
 function createIndexHTML(content: string, options: PlaygroundOptions) {


### PR DESCRIPTION
- Introduced a maximum URL length constant and validation in the createPlaygroundURL function to ensure URLs do not exceed 32,768 characters.
- Added tests to verify that errors are thrown when the URL length limit is exceeded, ensuring error handling in service and utils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playground URL generation to enforce a maximum URL length and return a clear “limit exceeded” error when the playground base URL is configured.
  * Enhanced URL serialization to safely encode large payloads without failing on oversized data.
* **Tests**
  * Added coverage for URL-length enforcement, including browser-boundary scenarios and updated serialization behavior.
* **Chores / CI**
  * Updated the GitHub Pages artifact upload to include hidden files under the built pages output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->