### PR TITLE
fix(core): restore preferences input label capitalization

### DIFF
--- a/projects/core/.visual/preferences-input.dark.png
+++ b/projects/core/.visual/preferences-input.dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:326728e3ac2dcde305e9ddf8627f7b0ec1de37646753cecb2af7c8f26d05f287
-size 13141
+oid sha256:a4598a40ebe1424262759adeb1cfc28c0f78bc6b69f30a78b23b41a10579b838
+size 13390

--- a/projects/core/.visual/preferences-input.png
+++ b/projects/core/.visual/preferences-input.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d694e219b95adeb2eddf1b4d0b3ccd64e61e966f6f50f4e1ae9c7f32e71b648
-size 13431
+oid sha256:fd31c6640e91dcd9879f4ab082ce45142347fbf1c1d6be9a2b1223c295dd2280
+size 13380

--- a/projects/core/src/preferences-input/preferences-input.css
+++ b/projects/core/src/preferences-input/preferences-input.css
@@ -14,6 +14,11 @@
   flex-direction: column;
 }
 
+nve-control,
+nve-switch {
+  --label-text-transform: capitalize;
+}
+
 nve-menu {
   --width: 100%;
 }

--- a/projects/core/src/preferences-input/preferences-input.test.ts
+++ b/projects/core/src/preferences-input/preferences-input.test.ts
@@ -39,6 +39,16 @@ describe(`${PreferencesInput.metadata.tag}: style check`, () => {
     expect(customElements.get(PreferencesInput.metadata.tag)).toBeDefined();
   });
 
+  it('should capitalize the color scheme label', () => {
+    const label = element.shadowRoot.querySelector('label');
+
+    if (!(label instanceof HTMLLabelElement)) {
+      throw new Error('Expected a color scheme label');
+    }
+
+    expect(getComputedStyle(label).textTransform).toBe('capitalize');
+  });
+
   /**
    * Test form properties
    */


### PR DESCRIPTION
- Restores capitalized labels in the preferences input and refreshes visual baselines.
- Adds regression coverage for label capitalization via explicit unit test.
- The previous lowercase regression changed only ~0.46% of pixels in each visual test; the runner rounded this down to 0%, so it passed the <1% threshold and retained the older capitalized baselines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized label text casing in preferences inputs so related controls now display capitalized labels consistently.

* **Tests**
  * Added coverage to verify the label styling is applied as expected in the component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->