### PR TITLE
feat(forms): coordinate interest and popover interactions

### DIFF
--- a/projects/core/src/alert/alert.test.lighthouse.ts
+++ b/projects/core/src/alert/alert.test.lighthouse.ts
@@ -16,7 +16,7 @@ describe('alert lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(23.3);
+    expect(report.payload.javascript.kb).toBeLessThan(23.4);
   });
 
   test('alert-group should meet lighthouse benchmarks', async () => {
@@ -33,6 +33,6 @@ describe('alert lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(23.3);
+    expect(report.payload.javascript.kb).toBeLessThan(23.4);
   });
 });

--- a/projects/core/src/combobox/combobox.test.lighthouse.ts
+++ b/projects/core/src/combobox/combobox.test.lighthouse.ts
@@ -25,7 +25,7 @@ describe('combobox lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(36.1);
+    expect(report.payload.javascript.kb).toBeLessThan(36.2);
   });
 
   test('combobox multi select with large dataset should meet lighthouse benchmarks', async () => {

--- a/projects/core/src/copy-button/copy-button.test.lighthouse.ts
+++ b/projects/core/src/copy-button/copy-button.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('copy-button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(26);
+    expect(report.payload.javascript.kb).toBeLessThan(26.2);
   });
 });

--- a/projects/core/src/datetime/datetime.test.lighthouse.ts
+++ b/projects/core/src/datetime/datetime.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('datetime lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.5);
+    expect(report.payload.javascript.kb).toBeLessThan(25.6);
   });
 });

--- a/projects/core/src/dialog/dialog.test.lighthouse.ts
+++ b/projects/core/src/dialog/dialog.test.lighthouse.ts
@@ -25,6 +25,6 @@ describe('dialog lighthouse report', () => {
     expect(report.scores.performance).toBeGreaterThan(97); // bfcache
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(24.9);
+    expect(report.payload.javascript.kb).toBeLessThan(25);
   });
 });

--- a/projects/core/src/drawer/drawer.test.lighthouse.ts
+++ b/projects/core/src/drawer/drawer.test.lighthouse.ts
@@ -18,6 +18,6 @@ describe('drawer lighthouse report', () => {
     expect(report.scores.performance).toBeGreaterThan(98); // bfcache
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.4);
+    expect(report.payload.javascript.kb).toBeLessThan(25.5);
   });
 });

--- a/projects/core/src/icon-button/icon-button.test.lighthouse.ts
+++ b/projects/core/src/icon-button/icon-button.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('icon-button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(19.5);
+    expect(report.payload.javascript.kb).toBeLessThan(19.6);
   });
 });

--- a/projects/core/src/index.test.lighthouse.ts
+++ b/projects/core/src/index.test.lighthouse.ts
@@ -15,7 +15,7 @@ describe('lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.requests['index.js'].kb).toBeLessThan(130.5);
+    expect(report.payload.javascript.requests['index.js'].kb).toBeLessThan(130.6);
 
     // if sudden drop in size, check vite bundle config and bundle demo to ensure side effects are properly preserved
     expect(report.payload.javascript.requests['index.js'].kb).toBeGreaterThan(120);

--- a/projects/core/src/menu/menu.test.lighthouse.ts
+++ b/projects/core/src/menu/menu.test.lighthouse.ts
@@ -21,6 +21,6 @@ describe('menu lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(16);
+    expect(report.payload.javascript.kb).toBeLessThan(16.1);
   });
 });

--- a/projects/core/src/month/month.test.lighthouse.ts
+++ b/projects/core/src/month/month.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('month lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.5);
+    expect(report.payload.javascript.kb).toBeLessThan(25.6);
   });
 });

--- a/projects/core/src/notification/notification.test.lighthouse.ts
+++ b/projects/core/src/notification/notification.test.lighthouse.ts
@@ -17,6 +17,6 @@ describe('notification lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.3);
+    expect(report.payload.javascript.kb).toBeLessThan(25.4);
   });
 });

--- a/projects/core/src/panel/panel.test.lighthouse.ts
+++ b/projects/core/src/panel/panel.test.lighthouse.ts
@@ -27,6 +27,6 @@ describe('panel lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(21.5);
+    expect(report.payload.javascript.kb).toBeLessThan(21.6);
   });
 });

--- a/projects/core/src/preferences-input/preferences-input.test.lighthouse.ts
+++ b/projects/core/src/preferences-input/preferences-input.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('preferences-input lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(32.6);
+    expect(report.payload.javascript.kb).toBeLessThan(32.7);
   });
 });

--- a/projects/core/src/sort-button/sort-button.test.lighthouse.ts
+++ b/projects/core/src/sort-button/sort-button.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('sort-button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(18.8);
+    expect(report.payload.javascript.kb).toBeLessThan(18.9);
   });
 });

--- a/projects/core/src/steps/steps.test.lighthouse.ts
+++ b/projects/core/src/steps/steps.test.lighthouse.ts
@@ -20,6 +20,6 @@ describe('steps lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(23.7);
+    expect(report.payload.javascript.kb).toBeLessThan(23.8);
   });
 });

--- a/projects/core/src/tag/tag.test.lighthouse.ts
+++ b/projects/core/src/tag/tag.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('tag lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(18.6);
+    expect(report.payload.javascript.kb).toBeLessThan(18.7);
   });
 });

--- a/projects/core/src/toast/toast.test.lighthouse.ts
+++ b/projects/core/src/toast/toast.test.lighthouse.ts
@@ -17,6 +17,6 @@ describe('toast lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(24.6);
+    expect(report.payload.javascript.kb).toBeLessThan(24.8);
   });
 });

--- a/projects/core/src/tooltip/tooltip.examples.ts
+++ b/projects/core/src/tooltip/tooltip.examples.ts
@@ -14,6 +14,7 @@ import '@nvidia-elements/core/badge/define.js';
 import '@nvidia-elements/core/icon/define.js';
 import '@nvidia-elements/core/icon-button/define.js';
 import '@nvidia-elements/core/dialog/define.js';
+import '@nvidia-elements/core/dropdown/define.js';
 import type { Badge } from '@nvidia-elements/core/badge';
 
 export default {
@@ -393,6 +394,17 @@ export const NestedDynamic = {
   </section>
 </nve-dialog>
 <nve-tooltip id="tooltip">test</nve-tooltip>
+  `
+};
+
+/**
+ * @summary Button combining interestfor and popovertarget for coordinated tooltip and dropdown behavior.
+ */
+export const PopoverInterest = {
+  render: () => html`
+<nve-button interestfor="tooltip" popovertarget="dropdown">Button</nve-button>
+<nve-tooltip id="tooltip">tooltip</nve-tooltip>
+<nve-dropdown id="dropdown">dropdown content</nve-dropdown>
   `
 };
 

--- a/projects/core/src/tooltip/tooltip.test.ts
+++ b/projects/core/src/tooltip/tooltip.test.ts
@@ -2,12 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { html } from 'lit';
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { createFixture, removeFixture, elementIsStable, emulateMouseEnter, untilEvent } from '@internals/testing';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createFixture,
+  removeFixture,
+  elementIsStable,
+  emulateClick,
+  emulateMouseEnter,
+  untilEvent
+} from '@internals/testing';
 import { Tooltip } from '@nvidia-elements/core/tooltip';
 import { Button } from '@nvidia-elements/core/button';
+import type { Dropdown } from '@nvidia-elements/core/dropdown';
 import '@nvidia-elements/core/tooltip/define.js';
 import '@nvidia-elements/core/button/define.js';
+import '@nvidia-elements/core/dropdown/define.js';
 
 describe(Tooltip.metadata.tag, () => {
   let fixture: HTMLElement;
@@ -26,6 +35,7 @@ describe(Tooltip.metadata.tag, () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     removeFixture(fixture);
   });
 
@@ -62,11 +72,6 @@ describe(Tooltip.metadata.tag, () => {
     expect(element._internals.role).toBe('tooltip');
   });
 
-  it('should default with an open delay set to undefined', async () => {
-    await elementIsStable(element);
-    expect(element.openDelay).toBeUndefined();
-  });
-
   it('should default with an interest delay start set 0.5s', async () => {
     await elementIsStable(element);
     expect(getComputedStyle(element).getPropertyValue('interest-delay-start')).toBe('0.5s');
@@ -79,17 +84,102 @@ describe(Tooltip.metadata.tag, () => {
     expect(element.getAttribute('status')).toBe('muted');
   });
 
-  it('if open-delay set, display tooltip after waiting for delayed time', async () => {
-    element.hidePopover();
-    element.openDelay = 500;
-    element.trigger = trigger;
+  it('should display the tooltip after the interest delay', async () => {
+    vi.useFakeTimers();
+    element.style.setProperty('interest-delay-start', '50ms');
     await elementIsStable(element);
-    await elementIsStable(trigger);
+
+    emulateMouseEnter(trigger);
+    vi.advanceTimersByTime(49);
     expect(element.matches(':popover-open')).toBe(false);
 
-    const open = untilEvent(element, 'open');
-    emulateMouseEnter(trigger);
-    expect(await open).toBeDefined();
+    vi.advanceTimersByTime(1);
     expect(element.matches(':popover-open')).toBe(true);
+  });
+});
+
+describe(`${Tooltip.metadata.tag}: popover interest handover`, () => {
+  let fixture: HTMLElement;
+  let element: Tooltip;
+  let dropdown: Dropdown;
+  let trigger: Button;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`
+      <nve-tooltip id="tooltip">hello</nve-tooltip>
+      <nve-dropdown id="dropdown"></nve-dropdown>
+      <nve-button interestfor="tooltip" popovertarget="dropdown">button</nve-button>
+    `);
+    element = fixture.querySelector('#tooltip');
+    dropdown = fixture.querySelector('#dropdown');
+    trigger = fixture.querySelector(Button.metadata.tag);
+    await elementIsStable(element);
+    await elementIsStable(dropdown);
+    await elementIsStable(trigger);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    removeFixture(fixture);
+  });
+
+  it('should hide an open tooltip when its trigger opens an interactive popover', async () => {
+    element.style.setProperty('interest-delay-start', '0s');
+    await elementIsStable(element);
+
+    const tooltipOpen = untilEvent(element, 'open');
+    emulateMouseEnter(trigger);
+    await tooltipOpen;
+    expect(element.matches(':popover-open')).toBe(true);
+
+    const dropdownOpen = untilEvent(dropdown, 'open');
+    emulateClick(trigger);
+    await dropdownOpen;
+    expect(element.matches(':popover-open')).toBe(false);
+    expect(trigger.popoverTargetElement).toBe(dropdown);
+    expect(dropdown.matches(':popover-open')).toBe(true);
+
+    emulateMouseEnter(trigger);
+    expect(element.matches(':popover-open')).toBe(false);
+  });
+
+  it('should cancel a pending tooltip when its trigger opens an interactive popover', async () => {
+    vi.useFakeTimers();
+    element.style.setProperty('interest-delay-start', '50ms');
+    await elementIsStable(element);
+
+    emulateMouseEnter(trigger);
+    emulateClick(trigger);
+    expect(trigger.popoverTargetElement).toBe(dropdown);
+    expect(dropdown.matches(':popover-open')).toBe(true);
+    vi.advanceTimersByTime(50);
+
+    expect(element.matches(':popover-open')).toBe(false);
+  });
+
+  it('should preserve a pending tooltip when opening the interactive popover is canceled', async () => {
+    vi.useFakeTimers();
+    element.style.setProperty('interest-delay-start', '50ms');
+    dropdown.addEventListener('beforetoggle', event => event.preventDefault(), { once: true });
+    await elementIsStable(element);
+
+    emulateMouseEnter(trigger);
+    emulateClick(trigger);
+    expect(dropdown.matches(':popover-open')).toBe(false);
+    vi.advanceTimersByTime(50);
+
+    expect(element.matches(':popover-open')).toBe(true);
+  });
+
+  it('should not revive a tooltip when dismissal restores non-focus-visible focus', async () => {
+    const focusVisibleMatch = vi.spyOn(trigger, 'matches').mockReturnValue(false);
+
+    emulateClick(trigger);
+    dropdown.hidePopover();
+    trigger.dispatchEvent(new FocusEvent('focus'));
+
+    expect(element.matches(':popover-open')).toBe(false);
+    expect(focusVisibleMatch).toHaveBeenCalledWith(':focus-visible');
   });
 });

--- a/projects/core/src/tree/tree.test.lighthouse.ts
+++ b/projects/core/src/tree/tree.test.lighthouse.ts
@@ -27,6 +27,6 @@ describe('tree lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(29.7);
+    expect(report.payload.javascript.kb).toBeLessThan(29.8);
   });
 });

--- a/projects/core/src/week/week.test.lighthouse.ts
+++ b/projects/core/src/week/week.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('week lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.5);
+    expect(report.payload.javascript.kb).toBeLessThan(25.6);
   });
 });

--- a/projects/forms/src/internal/controllers/type-interest-invoker.controller.test.ts
+++ b/projects/forms/src/internal/controllers/type-interest-invoker.controller.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { html } from 'lit';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createFixture, removeFixture, untilEvent } from '@internals/testing';
 
 import { TypeInterestInvokerController } from './type-interest-invoker.controller.js';
@@ -12,6 +12,7 @@ type InterestTestEvent = Event & { source: HTMLElement };
 
 class InterestInvokerControllerTestElement extends HTMLElement {
   interestForElement: HTMLElement | null = null;
+  popoverTargetElement: HTMLElement | null = null;
   #controllers = new Set<ReactiveController>();
 
   constructor() {
@@ -41,6 +42,7 @@ describe('InterestInvokerController', () => {
 
   afterEach(() => {
     removeFixture(fixture);
+    vi.restoreAllMocks();
   });
 
   it('should dispatch interest and loseinterest events from pointer hover', async () => {
@@ -62,7 +64,7 @@ describe('InterestInvokerController', () => {
     expect((await loseinterest).source).toBe(element);
   });
 
-  it('should dispatch interest and loseinterest events from focus and blur', async () => {
+  it('should dispatch interest and loseinterest events from focus-visible focus and blur', async () => {
     fixture = await createFixture(html`
       <interest-invoker-controller-test-element interestfor="target"></interest-invoker-controller-test-element>
       <div id="target"></div>
@@ -73,12 +75,54 @@ describe('InterestInvokerController', () => {
     const target = fixture.querySelector<HTMLElement>('#target')!;
     const interest = untilEvent<InterestTestEvent>(target, 'interest');
     const loseinterest = untilEvent<InterestTestEvent>(target, 'loseinterest');
+    const focusVisibleMatch = vi.spyOn(element, 'matches').mockReturnValue(true);
 
     element.dispatchEvent(new FocusEvent('focus'));
     element.dispatchEvent(new FocusEvent('blur'));
 
     expect((await interest).source).toBe(element);
     expect((await loseinterest).source).toBe(element);
+    expect(focusVisibleMatch).toHaveBeenCalledWith(':focus-visible');
+  });
+
+  it('should not dispatch interest from focus that is not focus-visible', async () => {
+    fixture = await createFixture(html`
+      <interest-invoker-controller-test-element interestfor="target"></interest-invoker-controller-test-element>
+      <div id="target"></div>
+    `);
+    const element = fixture.querySelector<InterestInvokerControllerTestElement>(
+      'interest-invoker-controller-test-element'
+    )!;
+    const target = fixture.querySelector<HTMLElement>('#target')!;
+    const interest = vi.fn();
+    target.addEventListener('interest', interest);
+    const focusVisibleMatch = vi.spyOn(element, 'matches').mockReturnValue(false);
+
+    element.dispatchEvent(new FocusEvent('focus'));
+
+    expect(interest).not.toHaveBeenCalled();
+    expect(focusVisibleMatch).toHaveBeenCalledWith(':focus-visible');
+  });
+
+  it('should not dispatch interest while its popover target is open', async () => {
+    fixture = await createFixture(html`
+      <interest-invoker-controller-test-element interestfor="tooltip"></interest-invoker-controller-test-element>
+      <div id="tooltip"></div>
+      <div id="popover" popover>popover</div>
+    `);
+    const element = fixture.querySelector<InterestInvokerControllerTestElement>(
+      'interest-invoker-controller-test-element'
+    )!;
+    const tooltip = fixture.querySelector<HTMLElement>('#tooltip')!;
+    const popover = fixture.querySelector<HTMLElement>('[popover]')!;
+    const interest = vi.fn();
+    tooltip.addEventListener('interest', interest);
+    element.popoverTargetElement = popover;
+    popover.showPopover();
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+
+    expect(interest).not.toHaveBeenCalled();
   });
 
   it('should support direct interestForElement references', async () => {

--- a/projects/forms/src/internal/controllers/type-interest-invoker.controller.ts
+++ b/projects/forms/src/internal/controllers/type-interest-invoker.controller.ts
@@ -8,6 +8,7 @@ type InterestEvent = Event & { source: HTMLElement };
 
 type InterestInvokerHost = ReactiveElement & {
   interestForElement: HTMLElement | null;
+  popoverTargetElement: HTMLElement | null;
 };
 
 export class TypeInterestInvokerController<T extends InterestInvokerHost> implements ReactiveController {
@@ -29,12 +30,20 @@ export class TypeInterestInvokerController<T extends InterestInvokerHost> implem
     this.host.removeEventListener('blur', this.#onLoseInterest);
   }
 
-  #onInterest = () => {
+  #onInterest = (event: Event) => {
+    if (event.type === 'focus' && !this.host.matches(':focus-visible')) {
+      return;
+    }
+
+    if (this.host.popoverTargetElement?.matches(':popover-open')) {
+      return;
+    }
+
     this.#updateInterestForElement();
     if (this.host.interestForElement) {
-      const event = new Event('interest', { cancelable: true }) as InterestEvent;
-      event.source = this.host;
-      this.host.interestForElement.dispatchEvent(event);
+      const interest = new Event('interest', { cancelable: true }) as InterestEvent;
+      interest.source = this.host;
+      this.host.interestForElement.dispatchEvent(interest);
     }
   };
 

--- a/projects/forms/src/internal/controllers/type-popover-trigger.controller.test.ts
+++ b/projects/forms/src/internal/controllers/type-popover-trigger.controller.test.ts
@@ -11,6 +11,7 @@ import type { ReactiveController } from './types.js';
 
 class PopoverTriggerControllerTestElement extends HTMLElement {
   disabled = false;
+  interestForElement: HTMLElement | null = null;
   popoverTargetAction?: PopoverTargetAction;
   popoverTargetElement: HTMLElement | null = null;
   popovertarget?: string;
@@ -64,6 +65,102 @@ describe('PopoverTriggerController', () => {
     expect(togglePopover).toHaveBeenCalledWith({ source: element });
   });
 
+  it('should not invoke a popover from a canceled click', async () => {
+    fixture = await createFixture(html`
+      <popover-trigger-controller-test-element></popover-trigger-controller-test-element>
+      <div id="popover" popover>popover</div>
+    `);
+    const element = fixture.querySelector<PopoverTriggerControllerTestElement>(
+      'popover-trigger-controller-test-element'
+    )!;
+    const popover = fixture.querySelector<HTMLElement>('[popover]')!;
+    const togglePopover = vi.spyOn(popover, 'togglePopover').mockImplementation(() => false);
+    fixture.addEventListener('click', event => event.preventDefault(), { capture: true });
+    element.popoverTargetElement = popover;
+
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(togglePopover).not.toHaveBeenCalled();
+  });
+
+  it('should follow a changed popover target id', async () => {
+    fixture = await createFixture(html`
+      <popover-trigger-controller-test-element></popover-trigger-controller-test-element>
+      <div id="tooltip"></div>
+      <div id="first" popover>first</div>
+      <div id="second" popover>second</div>
+    `);
+    const element = fixture.querySelector<PopoverTriggerControllerTestElement>(
+      'popover-trigger-controller-test-element'
+    )!;
+    const tooltip = fixture.querySelector<HTMLElement>('#tooltip')!;
+    const first = fixture.querySelector<HTMLElement>('#first')!;
+    const second = fixture.querySelector<HTMLElement>('#second')!;
+    const loseInterest = vi.fn();
+    tooltip.addEventListener('loseinterest', loseInterest);
+
+    element.interestForElement = tooltip;
+    element.popoverTargetAction = 'show';
+    element.popovertarget = 'first';
+    await emulateClick(element);
+    first.hidePopover();
+
+    loseInterest.mockClear();
+    element.popovertarget = 'second';
+    await emulateClick(element);
+
+    expect(element.popoverTargetElement).toBe(second);
+    expect(first.matches(':popover-open')).toBe(false);
+    expect(second.matches(':popover-open')).toBe(true);
+    expect(loseInterest).toHaveBeenCalledOnce();
+  });
+
+  it('should preserve tooltip interest when opening is canceled', async () => {
+    fixture = await createFixture(html`
+      <popover-trigger-controller-test-element></popover-trigger-controller-test-element>
+      <div id="tooltip"></div>
+      <div id="popover" popover>popover</div>
+    `);
+    const element = fixture.querySelector<PopoverTriggerControllerTestElement>(
+      'popover-trigger-controller-test-element'
+    )!;
+    const tooltip = fixture.querySelector<HTMLElement>('#tooltip')!;
+    const popover = fixture.querySelector<HTMLElement>('[popover]')!;
+    const loseInterest = vi.fn();
+    tooltip.addEventListener('loseinterest', loseInterest);
+    popover.addEventListener('beforetoggle', event => event.preventDefault());
+    element.interestForElement = tooltip;
+    element.popoverTargetElement = popover;
+
+    await emulateClick(element);
+
+    expect(popover.matches(':popover-open')).toBe(false);
+    expect(loseInterest).not.toHaveBeenCalled();
+  });
+
+  it('should preserve tooltip interest when toggling a popover closed', async () => {
+    fixture = await createFixture(html`
+      <popover-trigger-controller-test-element></popover-trigger-controller-test-element>
+      <div id="tooltip"></div>
+      <div id="popover" popover>popover</div>
+    `);
+    const element = fixture.querySelector<PopoverTriggerControllerTestElement>(
+      'popover-trigger-controller-test-element'
+    )!;
+    const tooltip = fixture.querySelector<HTMLElement>('#tooltip')!;
+    const popover = fixture.querySelector<HTMLElement>('[popover]')!;
+    const loseInterest = vi.fn();
+    tooltip.addEventListener('loseinterest', loseInterest);
+    element.interestForElement = tooltip;
+    element.popoverTargetElement = popover;
+    popover.showPopover();
+
+    await emulateClick(element);
+
+    expect(popover.matches(':popover-open')).toBe(false);
+    expect(loseInterest).not.toHaveBeenCalled();
+  });
+
   it('should support direct popover target properties and show or hide actions', async () => {
     fixture = await createFixture(html`
       <popover-trigger-controller-test-element></popover-trigger-controller-test-element>
@@ -107,7 +204,7 @@ describe('PopoverTriggerController', () => {
     expect(togglePopover).not.toHaveBeenCalled();
   });
 
-  it('should pass anchored popover sources', async () => {
+  it('should pass the anchor as the popover source when the target has an anchor', async () => {
     fixture = await createFixture(html`
       <popover-trigger-controller-test-element></popover-trigger-controller-test-element>
       <div id="anchor"></div>
@@ -126,6 +223,39 @@ describe('PopoverTriggerController', () => {
     await emulateClick(element);
 
     expect(showPopover).toHaveBeenCalledWith({ source: anchor });
+  });
+
+  it('should hand over tooltip interest after an anchored target popover opens from the trigger', async () => {
+    fixture = await createFixture(html`
+      <popover-trigger-controller-test-element interestfor="tooltip" popovertarget="popover"></popover-trigger-controller-test-element>
+      <div id="tooltip"></div>
+      <div id="anchor"></div>
+      <div id="popover" popover>popover</div>
+    `);
+    const element = fixture.querySelector<PopoverTriggerControllerTestElement>(
+      'popover-trigger-controller-test-element'
+    )!;
+    const tooltip = fixture.querySelector<HTMLElement>('#tooltip')!;
+    const anchor = fixture.querySelector<HTMLElement>('#anchor')!;
+    const popover = fixture.querySelector<HTMLElement>('[popover]')!;
+    let interestSource: HTMLElement | undefined;
+    let popoverSource: HTMLElement | null | undefined;
+    tooltip.addEventListener('loseinterest', event => {
+      interestSource = (event as Event & { source: HTMLElement }).source;
+    });
+    popover.addEventListener('beforetoggle', event => {
+      popoverSource = (event as ToggleEvent).source;
+    });
+
+    Object.defineProperty(popover, 'anchor', { configurable: true, value: 'anchor' });
+    element.interestForElement = tooltip;
+    element.popovertarget = 'popover';
+    await emulateClick(element);
+
+    expect(element.popoverTargetElement).toBe(popover);
+    expect(popover.matches(':popover-open')).toBe(true);
+    expect(popoverSource).toBe(anchor);
+    expect(interestSource).toBe(element);
   });
 
   it('should remove click behavior on disconnect', async () => {

--- a/projects/forms/src/internal/controllers/type-popover-trigger.controller.ts
+++ b/projects/forms/src/internal/controllers/type-popover-trigger.controller.ts
@@ -6,8 +6,11 @@ import { getFlattenedDOMTree, getHostAnchor } from '../utils.js';
 import type { PopoverAnchorElement } from '../utils.js';
 import type { ReactiveController, ReactiveElement } from './types.js';
 
+type InterestEvent = Event & { source: HTMLElement };
+
 type PopoverTriggerHost = ReactiveElement & {
   disabled: boolean;
+  interestForElement: HTMLElement | null;
   popoverTargetAction?: PopoverTargetAction;
   popoverTargetElement: HTMLElement | null;
   popovertarget?: string;
@@ -26,30 +29,80 @@ export class TypePopoverTriggerController<T extends PopoverTriggerHost> implemen
     this.host.removeEventListener('click', this.#onClick);
   }
 
-  #onClick = () => {
-    let source = this.host as HTMLElement;
-    let popoverTargetElement = this.host.popoverTargetElement;
+  #resolvedPopoverTarget: HTMLElement | null | undefined;
 
-    if (!popoverTargetElement && this.host.popovertarget) {
-      popoverTargetElement =
-        getFlattenedDOMTree(this.host.getRootNode()).find(element => element.id === this.host.popovertarget) ?? null;
-      this.host.popoverTargetElement = popoverTargetElement;
+  #resolvePopoverTarget() {
+    const popoverTargetElement = this.host.popoverTargetElement;
+    const controllerResolvedTarget = popoverTargetElement === this.#resolvedPopoverTarget;
+
+    if (!this.host.popovertarget) {
+      this.#resolvedPopoverTarget = undefined;
+      if (controllerResolvedTarget) {
+        this.host.popoverTargetElement = null;
+        return null;
+      }
+
+      return popoverTargetElement;
     }
 
-    if ((popoverTargetElement as PopoverAnchorElement)?.anchor) {
-      source = getHostAnchor(popoverTargetElement as PopoverAnchorElement);
+    if (popoverTargetElement && !controllerResolvedTarget) {
+      return popoverTargetElement;
     }
 
-    if (!popoverTargetElement || this.host.disabled) {
+    const resolvedPopoverTarget =
+      getFlattenedDOMTree(this.host.getRootNode()).find(element => element.id === this.host.popovertarget) ?? null;
+    if (resolvedPopoverTarget !== popoverTargetElement) {
+      this.host.popoverTargetElement = resolvedPopoverTarget;
+    }
+    this.#resolvedPopoverTarget = resolvedPopoverTarget;
+
+    return resolvedPopoverTarget;
+  }
+
+  #onClick = (event: MouseEvent) => {
+    if (event.defaultPrevented || this.host.disabled) {
       return;
     }
 
+    const popoverTargetElement = this.#resolvePopoverTarget();
+    if (!popoverTargetElement) {
+      return;
+    }
+
+    if (this.#invokePopover(popoverTargetElement)) {
+      this.#handoverInterest();
+    }
+  };
+
+  #getPopoverSource(popoverTargetElement: HTMLElement) {
+    if ((popoverTargetElement as PopoverAnchorElement).anchor) {
+      return getHostAnchor(popoverTargetElement as PopoverAnchorElement);
+    }
+
+    return this.host as HTMLElement;
+  }
+
+  #invokePopover(popoverTargetElement: HTMLElement) {
     if (this.host.popoverTargetAction === 'hide') {
       popoverTargetElement.hidePopover();
-    } else if (this.host.popoverTargetAction === 'show') {
+      return false;
+    }
+
+    const source = this.#getPopoverSource(popoverTargetElement);
+    if (this.host.popoverTargetAction === 'show') {
       popoverTargetElement.showPopover({ source });
     } else {
       popoverTargetElement.togglePopover({ source });
     }
-  };
+
+    return popoverTargetElement.matches(':popover-open');
+  }
+
+  #handoverInterest() {
+    if (this.host.interestForElement) {
+      const loseInterest = new Event('loseinterest', { cancelable: true }) as InterestEvent;
+      loseInterest.source = this.host;
+      this.host.interestForElement.dispatchEvent(loseInterest);
+    }
+  }
 }

--- a/projects/forms/src/mixins/button.test.ts
+++ b/projects/forms/src/mixins/button.test.ts
@@ -843,6 +843,32 @@ describe('ButtonFormControlMixin', () => {
       expect(popover.matches(':popover-open')).toBe(true);
     });
 
+    it('should follow a changed popover target', async () => {
+      fixture = await createFixture(html`
+        <button-form-control-mixin-test-element
+          popovertarget="first"
+          popovertargetaction="show"
+        ></button-form-control-mixin-test-element>
+        <div popover id="first">first</div>
+        <div popover id="second">second</div>
+      `);
+      button = fixture.querySelector<ButtonFormControlMixinTestElement>('button-form-control-mixin-test-element')!;
+      const first = fixture.querySelector<HTMLElement>('#first')!;
+      const second = fixture.querySelector<HTMLElement>('#second')!;
+      await elementIsStable(button);
+
+      emulateClick(button);
+      first.hidePopover();
+
+      button.popovertarget = 'second';
+      await elementIsStable(button);
+      emulateClick(button);
+
+      expect(button.popoverTargetElement).toBe(second);
+      expect(first.matches(':popover-open')).toBe(false);
+      expect(second.matches(':popover-open')).toBe(true);
+    });
+
     it('should support popover target properties and show or hide actions', async () => {
       fixture = await createFixture(html`
         <button-form-control-mixin-test-element></button-form-control-mixin-test-element>
@@ -926,7 +952,7 @@ describe('ButtonFormControlMixin', () => {
       expect(button.interestForElement).toBe(null);
     });
 
-    it('should dispatch interest and loseinterest events from focus and blur', async () => {
+    it('should dispatch interest and loseinterest events from focus-visible focus and blur', async () => {
       fixture = await createFixture(html`
         <button-form-control-mixin-test-element interestfor="target"></button-form-control-mixin-test-element>
         <div id="target"></div>
@@ -936,12 +962,14 @@ describe('ButtonFormControlMixin', () => {
       await elementIsStable(button);
       const interest = untilEvent<InterestTestEvent>(target, 'interest');
       const loseinterest = untilEvent<InterestTestEvent>(target, 'loseinterest');
+      const focusVisibleMatch = vi.spyOn(button, 'matches').mockReturnValue(true);
 
       button.dispatchEvent(new FocusEvent('focus'));
       button.dispatchEvent(new FocusEvent('blur'));
 
       expect((await interest).source).toBe(button);
       expect((await loseinterest).source).toBe(button);
+      expect(focusVisibleMatch).toHaveBeenCalledWith(':focus-visible');
     });
 
     it('should support direct interestForElement references', async () => {

--- a/projects/site/src/docs/elements/tooltip.md
+++ b/projects/site/src/docs/elements/tooltip.md
@@ -34,6 +34,10 @@ Learn more about native [Popover APIs](/docs/foundations/popovers/).
 
 {% example '@nvidia-elements/core/tooltip/tooltip.examples.json' 'Events' '{ "inline": false, "height": "280px" }' %}
 
+## Interactive Popover
+
+{% example '@nvidia-elements/core/tooltip/tooltip.examples.json' 'PopoverInterest' '{ "inline": false, "height": "260px" }' %}
+
 ## Open Delay
 
 {% api 'nve-tooltip', 'property' 'openDelay' %}


### PR DESCRIPTION
- Hand off tooltip interest when a shared trigger successfully opens its interactive popover.
- Suppress tooltip interest while the popover remains open.
- Limit focus-based interest to `:focus-visible` while preserving pointer behavior.
- Preserve explicit popover anchors and follow runtime target changes.
- Add focused tests and a documented tooltip/dropdown example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new interactive tooltip example demonstrating coordinated tooltip + popover control from a single trigger.
  * Updated tooltip documentation with an “Interactive Popover” section embedding the new example.
* **Bug Fixes**
  * Improved tooltip open/cancel timing to respect the configured delay.
  * Refined focus behavior to react only to `focus-visible`, and improved tooltip interest/loseinterest handover across popover open/close and prevented toggles (including anchored targets).
* **Tests**
  * Expanded timer/mock-based coverage for tooltip delays and popover interaction scenarios; adjusted Lighthouse JavaScript bundle-size thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->