### PR TITLE
fix(docs): enhance decorator transpilation

### DIFF
--- a/projects/internals/vite/package.json
+++ b/projects/internals/vite/package.json
@@ -11,6 +11,7 @@
   },
   "exports": {
     ".": "./src/index.js",
+    "./plugins/*.js": "./src/plugins/*.js",
     "./runners/*.js": "./src/runners/*.js",
     "./setup/*.js": "./src/setup/*.js",
     "./configs/*.js": "./src/configs/*.js"

--- a/projects/internals/vite/src/plugins/decorators.js
+++ b/projects/internals/vite/src/plugins/decorators.js
@@ -3,15 +3,28 @@ import { transformWithEsbuild } from 'vite';
 /**
  * - https://github.com/oxc-project/oxc/issues/9170
  * - https://vite.dev/guide/migration#javascript-transforms-by-oxc
+ * @param {{ experimentalDecorators?: boolean }} [options]
  */
-export const transpileDecorators = () => {
+export const transpileDecorators = ({ experimentalDecorators = false } = {}) => {
   return {
-    // Oxc preserves TC39 decorators (only transpiles legacy), but Istanbul's
-    // Babel parser can't parse them. Use esbuild to downlevel decorators.
+    // Oxc preserves TC39 decorators, but downstream runtimes and tooling don't
+    // consistently support them. Use esbuild to downlevel decorators.
     name: 'transpile-decorators',
     async transform(code, id) {
       if (!id.includes('.ts') || !/(?:^|\s)@\w+/m.test(code)) return null;
-      const result = await transformWithEsbuild(code, id, { target: 'es2022' });
+      const result = await transformWithEsbuild(code, id, {
+        target: 'es2022',
+        ...(experimentalDecorators
+          ? {
+              tsconfigRaw: {
+                compilerOptions: {
+                  experimentalDecorators: true,
+                  useDefineForClassFields: false
+                }
+              }
+            }
+          : {})
+      });
       return { code: result.code, map: result.map };
     }
   };

--- a/projects/site/eleventy.config.js
+++ b/projects/site/eleventy.config.js
@@ -2,6 +2,7 @@
 
 import { EleventyRenderPlugin, HtmlBasePlugin, IdAttributePlugin } from '@11ty/eleventy';
 import EleventyPluginVite from '@11ty/eleventy-plugin-vite';
+import { transpileDecorators } from '@internals/vite/plugins/decorators.js';
 import litPlugin from '@lit-labs/eleventy-plugin-lit';
 
 import { BASE_URL } from './src/_11ty/layouts/metadata.js';
@@ -144,6 +145,7 @@ export default function (eleventyConfig) {
             : undefined
       },
       plugins: [
+        transpileDecorators({ experimentalDecorators: true }),
         {
           name: 'remove-sourcemaps',
           transform(code) {


### PR DESCRIPTION
- Updated the `transpileDecorators` function to accept an options parameter for enabling experimental decorators.
- Added a new export pattern for plugins in `package.json` to support dynamic imports.
- Integrated the updated decorator transpilation in the Eleventy configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new plugin subpath, making plugin imports cleaner and more direct.
  * Enabled decorator syntax handling in the site’s build pipeline, improving compatibility for code that uses decorators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->