### PR TITLE
fix(core): align root tree nodes

### DIFF
--- a/projects/core/.visual/tree.dark.png
+++ b/projects/core/.visual/tree.dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4a802670371a1b1b838f972990db6e02645f3e4faa15671283c24278fe13d65
-size 76953
+oid sha256:9d62e5a9d8c33e98feadca9dbac9e781bf7543c569a3b9f82562d9c8195efbab
+size 30865

--- a/projects/core/.visual/tree.png
+++ b/projects/core/.visual/tree.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09ffdcb0873eca28b3de4a398218af6d273579a46cac9697e7ae7b31a41ca1a6
-size 76250
+oid sha256:9e440430014a9550ad463098dabf5b60acbaf18250b89eb786f85d44d5ee94b9
+size 29176

--- a/projects/core/src/tree/tree-node.test.ts
+++ b/projects/core/src/tree/tree-node.test.ts
@@ -132,6 +132,23 @@ describe(TreeNode.metadata.tag, () => {
     );
   });
 
+  it('should align leaf root nodes with expandable root nodes', async () => {
+    const leafHeader = element.shadowRoot!.querySelector<HTMLElement>('[part="_node-header"]')!;
+    const expandableHeader = nestedNodeElement.shadowRoot!.querySelector<HTMLElement>('[part="_node-header"]')!;
+
+    expect(leafHeader.getBoundingClientRect().x).toBe(expandableHeader.getBoundingClientRect().x);
+  });
+
+  it('should align multi-select leaf root nodes with expandable root nodes', async () => {
+    tree.selectable = 'multi';
+    await Promise.all([elementIsStable(tree), elementIsStable(element), elementIsStable(nestedNodeElement)]);
+
+    const leafHeader = element.shadowRoot!.querySelector<HTMLElement>('[part="_node-header"]')!;
+    const expandableHeader = nestedNodeElement.shadowRoot!.querySelector<HTMLElement>('[part="_node-header"]')!;
+
+    expect(leafHeader.getBoundingClientRect().x).toBe(expandableHeader.getBoundingClientRect().x);
+  });
+
   it('should show icon button if expandable', async () => {
     expect(element.shadowRoot.querySelector('nve-icon-button')).toBeFalsy();
 

--- a/projects/core/src/tree/tree.global.css
+++ b/projects/core/src/tree/tree.global.css
@@ -26,3 +26,12 @@ nve-tree-node > nve-tree-node:state(is-expandable):state(selectable-multi) {
 nve-tree-node:has(nve-tree-node:state(is-expandable))::part(_nodes) {
   padding-inline-start: var(--nve-ref-size-400);
 }
+
+nve-tree:has(> nve-tree-node:state(is-expandable)) > nve-tree-node:not(:state(is-expandable))::part(_node) {
+  padding-inline-start: var(--nve-ref-size-400);
+}
+
+nve-tree:has(> nve-tree-node:state(is-expandable):state(selectable-multi))
+  > nve-tree-node:not(:state(is-expandable)):state(selectable-multi)::part(_node) {
+  padding-inline-start: var(--nve-ref-size-500);
+}


### PR DESCRIPTION
Align leaf root nodes with expandable root siblings in `nve-tree`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree layout alignment so leaf nodes line up correctly with expandable nodes.
  * Preserved consistent alignment when multi-select mode is enabled.

* **Tests**
  * Added coverage for alignment in default selectable and multi-select tree states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->