### PR TITLE
fix(core): generate valid standalone framework declarations

### DIFF
--- a/projects/core/.stub/vue.d.ts
+++ b/projects/core/.stub/vue.d.ts
@@ -1,0 +1,4 @@
+/** Minimal Vue surface required to validate generated declaration types. */
+declare module 'vue' {
+  export type DefineComponent<Props> = new () => { $props: Props };
+}

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -37,6 +37,7 @@
     "build": "wireit",
     "build:icons": "wireit",
     "test": "wireit",
+    "test:types": "wireit",
     "test:watch": "wireit",
     "test:axe": "wireit",
     "test:ssr": "wireit",
@@ -991,6 +992,7 @@
         "lint",
         "build",
         "publint",
+        "test:types",
         "test:axe",
         "test:ssr",
         "test:coverage",
@@ -1021,6 +1023,7 @@
       "command": "NODE_ENV=production ELEMENTS_BUILD=true vite build",
       "clean": "if-file-deleted",
       "files": [
+        "../forms/src/mixins/**/*.ts",
         "../styles/dist/**/*.css",
         "../themes/dist/**/*.css",
         "../forms/dist/**/*.js",
@@ -1097,6 +1100,22 @@
       "env": {
         "NODE_ENV": "production"
       }
+    },
+    "test:types": {
+      "command": "tsc --project tsconfig.types.json",
+      "files": [
+        ".stub/vue.d.ts",
+        "dist/custom-elements-jsx.d.ts",
+        "dist/custom-elements-vue.d.ts",
+        "tsconfig.types.json"
+      ],
+      "output": [],
+      "dependencies": [
+        {
+          "script": "build",
+          "cascade": false
+        }
+      ]
     },
     "test:coverage": {
       "command": "vitest run --coverage",

--- a/projects/core/src/menu/menu.test.ts
+++ b/projects/core/src/menu/menu.test.ts
@@ -38,7 +38,7 @@ describe(Menu.metadata.tag, () => {
 
   it('should navigate between items with ArrowDown key', async () => {
     await elementIsStable(element);
-    const items = element.items;
+    const items = element.querySelectorAll('nve-menu-item');
     items[0].focus();
     expect(items[0].matches(':focus')).toBe(true);
 
@@ -49,7 +49,7 @@ describe(Menu.metadata.tag, () => {
 
   it('should navigate between items with ArrowUp key', async () => {
     await elementIsStable(element);
-    const items = element.items;
+    const items = element.querySelectorAll('nve-menu-item');
     items[1].focus();
     expect(items[1].matches(':focus')).toBe(true);
 
@@ -60,7 +60,7 @@ describe(Menu.metadata.tag, () => {
 
   it('should skip disabled items during keyboard navigation', async () => {
     await elementIsStable(element);
-    const items = element.items;
+    const items = element.querySelectorAll('nve-menu-item');
     items[1].disabled = true;
     await elementIsStable(element);
 

--- a/projects/core/src/menu/menu.ts
+++ b/projects/core/src/menu/menu.ts
@@ -55,7 +55,7 @@ export class Menu extends LitElement {
   /** @private */
   declare _internals: ElementInternals;
 
-  @queryAssignedElements() items!: MenuItem[];
+  @queryAssignedElements() private items!: MenuItem[];
 
   #scrollRAF: number | null = null;
 

--- a/projects/core/src/pagination/pagination.ts
+++ b/projects/core/src/pagination/pagination.ts
@@ -56,7 +56,7 @@ export class Pagination extends FormControlMixin<typeof LitElement, number>(LitE
   /**
    * The array of custom step-size.
    */
-  @property({ type: Array }) stepSizes = [10, 20, 50, 100];
+  @property({ type: Array }) stepSizes: number[] = [10, 20, 50, 100];
 
   /**
    * The total number of items.

--- a/projects/core/tsconfig.types.json
+++ b/projects/core/tsconfig.types.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "target": "ES2022",
+    "types": []
+  },
+  "files": [".stub/vue.d.ts", "dist/custom-elements-jsx.d.ts", "dist/custom-elements-vue.d.ts"]
+}

--- a/projects/internals/vite/src/plugins/cem.config.mjs
+++ b/projects/internals/vite/src/plugins/cem.config.mjs
@@ -350,6 +350,46 @@ function getTypeText(type, location) {
   return type.getText(location);
 }
 
+function isElementReferencePropertyType(type, seen = new Set()) {
+  const nonNullableTypes = type.getUnionTypes().filter(unionType => !unionType.isNull() && !unionType.isUndefined());
+
+  if (nonNullableTypes.length > 1) {
+    return nonNullableTypes.every(unionType => isElementReferencePropertyType(unionType, new Set(seen)));
+  }
+
+  const nonNullableType = nonNullableTypes[0] ?? type;
+  const symbolName = nonNullableType.getSymbol()?.getName() ?? nonNullableType.getAliasSymbol()?.getName();
+  if (symbolName === 'Element') {
+    return true;
+  }
+
+  const typeKey = nonNullableType.getText();
+  if (seen.has(typeKey)) {
+    return false;
+  }
+
+  seen.add(typeKey);
+  return nonNullableType.getBaseTypes().some(baseType => isElementReferencePropertyType(baseType, new Set(seen)));
+}
+
+// CEM attribute types normally follow the property's converted type. Element-reference attributes instead accept an
+// element id, so their attribute-facing type is string while the JavaScript property remains Element | null.
+function getCemAttributeTypeText(propertyType, propertyTypeText) {
+  return isElementReferencePropertyType(propertyType) ? 'string' : propertyTypeText;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function typeTextReferencesName(typeText, name) {
+  return new RegExp(`(?<![\\w$])${escapeRegExp(name)}(?![\\w$])`).test(typeText);
+}
+
+function replaceTypeName(typeText, name, replacement) {
+  return typeText.replace(new RegExp(`(?<![\\w$])${escapeRegExp(name)}(?![\\w$])`, 'g'), replacement);
+}
+
 function createMixinApiEntry(property, location, mixinName) {
   const declarations = property.getDeclarations();
   const declaration = declarations.find(item => typeof item.getJsDocs === 'function');
@@ -368,11 +408,16 @@ function createMixinApiEntry(property, location, mixinName) {
   }
 
   const attribute = attributeTag?.getCommentText()?.trim();
+  const propertyType = property.getTypeAtLocation(location);
+  const typeText = getTypeText(propertyType, location);
+  const requiresMixinTypeSpecialization = location
+    .getTypeParameters()
+    .some(typeParameter => typeTextReferencesName(typeText, typeParameter.getName()));
   const member = {
     kind: declarations.some(item => item.getKindName?.() === 'MethodSignature') ? 'method' : 'field',
     name: property.getName(),
     type: {
-      text: getTypeText(property.getTypeAtLocation(location), location)
+      text: typeText
     },
     description,
     inheritedFrom: {
@@ -391,11 +436,12 @@ function createMixinApiEntry(property, location, mixinName) {
 
   return {
     member,
+    requiresMixinTypeSpecialization,
     attribute: attribute
       ? {
           name: attribute,
           fieldName: member.name,
-          type: { ...member.type },
+          type: { text: getCemAttributeTypeText(propertyType, typeText) },
           description,
           inheritedFrom: member.inheritedFrom
         }
@@ -498,15 +544,76 @@ function addUniqueMember(declaration, member) {
   }
 }
 
-function addUniqueAttribute(declaration, attribute) {
+function isTypescriptElementReferencePropertyType(type, ts, seen = new Set()) {
+  const nonNullableTypes = type.isUnion()
+    ? type.types.filter(item => !(item.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)))
+    : [];
+
+  if (nonNullableTypes.length > 1) {
+    return nonNullableTypes.every(item => isTypescriptElementReferencePropertyType(item, ts, new Set(seen)));
+  }
+
+  const nonNullableType = nonNullableTypes[0] ?? type;
+  const symbolName = nonNullableType.getSymbol?.()?.getName() ?? nonNullableType.aliasSymbol?.getName();
+  if (symbolName === 'Element') {
+    return true;
+  }
+
+  if (seen.has(nonNullableType)) {
+    return false;
+  }
+
+  seen.add(nonNullableType);
+  return (nonNullableType.getBaseTypes?.() ?? []).some(baseType =>
+    isTypescriptElementReferencePropertyType(baseType, ts, new Set(seen))
+  );
+}
+
+// Mixin APIs are analyzed generically. Resolve type parameters against each concrete component before projection, then
+// preserve the distinction between element-valued JavaScript properties and their string-valued attributes.
+function resolveConcreteMixinAttributeType(modulePath, declarationName, memberName) {
+  const sourcePath = resolve(modulePath.replace(/^\//, '').replace(/\.js$/, '.ts'));
+  const sourceFile = runtimeEnvironment.program?.getSourceFile(sourcePath);
+  const ts = runtimeEnvironment.ts;
+  const typeChecker = runtimeEnvironment.typeChecker;
+  const classDeclaration = sourceFile?.statements.find(
+    statement => ts.isClassDeclaration(statement) && statement.name?.text === declarationName
+  );
+  const classType = classDeclaration && typeChecker.getTypeAtLocation(classDeclaration);
+  const property = classType && typeChecker.getPropertyOfType(classType, memberName);
+
+  if (!classDeclaration || !property) {
+    return null;
+  }
+
+  const type = typeChecker.getTypeOfSymbolAtLocation(property, classDeclaration);
+  const typeText = typeChecker.typeToString(type, classDeclaration, ts.TypeFormatFlags.NoTruncation);
+  return isTypescriptElementReferencePropertyType(type, ts) ? 'string' : typeText;
+}
+
+function addProjectedMixinAttribute(declaration, attribute, { modulePath, requiresMixinTypeSpecialization }) {
   if (!attribute) {
     return;
   }
 
   declaration.attributes ??= [];
-  if (!declaration.attributes.some(item => item.name === attribute.name || item.fieldName === attribute.fieldName)) {
-    declaration.attributes.push(structuredClone(attribute));
+  if (declaration.attributes.some(item => item.name === attribute.name || item.fieldName === attribute.fieldName)) {
+    return;
   }
+
+  const projectedAttribute = structuredClone(attribute);
+  if (requiresMixinTypeSpecialization) {
+    const concreteType = resolveConcreteMixinAttributeType(modulePath, declaration.name, attribute.fieldName);
+    if (!concreteType) {
+      throw new Error(
+        `Unable to specialize generic mixin attribute "${attribute.name}" from property "${attribute.fieldName}" on ${declaration.name} (${modulePath}).`
+      );
+    }
+
+    projectedAttribute.type = { ...projectedAttribute.type, text: concreteType };
+  }
+
+  declaration.attributes.push(projectedAttribute);
 }
 
 function mixinApiProjectionPlugin() {
@@ -516,17 +623,21 @@ function mixinApiProjectionPlugin() {
       const mixinApiRegistry = getMixinApiRegistry();
       const declarationRegistry = getDeclarationRegistry(customElementsManifest);
 
-      customElementsManifest.modules
-        .flatMap(module => module.declarations ?? [])
-        .filter(declaration => declaration.kind === 'class')
-        .forEach(declaration => {
-          getDeclarationMixins(declaration, declarationRegistry).forEach(mixin => {
-            mixinApiRegistry.get(mixin.name)?.forEach(({ member, attribute }) => {
-              addUniqueMember(declaration, member);
-              addUniqueAttribute(declaration, attribute);
+      customElementsManifest.modules.forEach(module => {
+        module.declarations
+          ?.filter(declaration => declaration.kind === 'class')
+          .forEach(declaration => {
+            getDeclarationMixins(declaration, declarationRegistry).forEach(mixin => {
+              mixinApiRegistry.get(mixin.name)?.forEach(({ member, attribute, requiresMixinTypeSpecialization }) => {
+                addUniqueMember(declaration, member);
+                addProjectedMixinAttribute(declaration, attribute, {
+                  modulePath: module.path,
+                  requiresMixinTypeSpecialization
+                });
+              });
             });
           });
-        });
+      });
     }
   };
 }
@@ -597,11 +708,147 @@ function dynamicSlotsPlugin() {
   };
 }
 
+// Framework declarations are standalone package entrypoints. Inline source interfaces reachable from published types.
+function getPublishedFrameworkTypeTexts(customElementsManifest) {
+  return customElementsManifest.modules
+    .flatMap(module => module.declarations ?? [])
+    .filter(declaration => declaration.tagName)
+    .flatMap(declaration => [...(declaration.attributes ?? []), ...(declaration.members ?? [])])
+    .map(item => item.type?.text)
+    .filter(Boolean);
+}
+
+function collectReachableStandaloneInterfaceTypes(customElementsManifest) {
+  const sourceInterfaceTypes = new Map();
+  const sourceRoot = resolve('src');
+  runtimeEnvironment.program
+    ?.getSourceFiles()
+    .filter(sourceFile => sourceFile.fileName.startsWith(sourceRoot))
+    .forEach(sourceFile => {
+      sourceFile.statements
+        .filter(statement => runtimeEnvironment.ts.isInterfaceDeclaration(statement))
+        .forEach(statement => sourceInterfaceTypes.set(statement.name.text, getInlineInterfaceTypeText(statement)));
+    });
+
+  const standaloneInterfaceTypes = new Map();
+  const pendingTypeTexts = getPublishedFrameworkTypeTexts(customElementsManifest);
+
+  for (let index = 0; index < pendingTypeTexts.length; index += 1) {
+    const typeText = pendingTypeTexts[index];
+
+    sourceInterfaceTypes.forEach((interfaceType, name) => {
+      if (standaloneInterfaceTypes.has(name) || !typeTextReferencesName(typeText, name)) {
+        return;
+      }
+
+      standaloneInterfaceTypes.set(name, interfaceType);
+      pendingTypeTexts.push(interfaceType);
+    });
+  }
+
+  return standaloneInterfaceTypes;
+}
+
+function getInlineInterfaceTypeText(declaration) {
+  const ts = runtimeEnvironment.ts;
+  const typeChecker = runtimeEnvironment.typeChecker;
+  const type = typeChecker.getTypeAtLocation(declaration);
+  const properties = typeChecker.getPropertiesOfType(type).map(property => {
+    const isOptional = Boolean(property.flags & ts.SymbolFlags.Optional);
+    const name = /^[A-Z_$][\w$]*$/i.test(property.name) ? property.name : JSON.stringify(property.name);
+    let propertyType = typeChecker.typeToString(
+      typeChecker.getTypeOfSymbolAtLocation(property, declaration),
+      declaration,
+      ts.TypeFormatFlags.NoTruncation
+    );
+
+    if (isOptional) {
+      propertyType = propertyType.replace(/ \| undefined$/, '');
+    }
+
+    return `${name}${isOptional ? '?' : ''}: ${propertyType}`;
+  });
+
+  return `{ ${properties.join('; ')} }`;
+}
+
+function expandStandaloneTypeText(type, standaloneInterfaceTypes, resolvingInterfaceNames = new Set()) {
+  let standaloneType = type ?? 'string';
+
+  standaloneInterfaceTypes.forEach((interfaceType, name) => {
+    if (!typeTextReferencesName(standaloneType, name)) {
+      return;
+    }
+
+    const expandedInterfaceType = resolvingInterfaceNames.has(name)
+      ? 'unknown'
+      : expandStandaloneTypeText(interfaceType, standaloneInterfaceTypes, new Set(resolvingInterfaceNames).add(name));
+
+    standaloneType = replaceTypeName(standaloneType, name, expandedInterfaceType);
+  });
+
+  return standaloneType;
+}
+
+// JSX and Vue generators normally replace an attributed property with its attribute alias. Preserve both bindings when
+// the alias has a different name and type because the attribute cannot represent the JavaScript property value.
+function exposeDistinctFrameworkPropertyBindings(declaration) {
+  declaration.members?.forEach(member => {
+    const attribute = declaration.attributes?.find(
+      item => item.name === member.attribute && item.fieldName === member.name
+    );
+
+    if (attribute && attribute.name !== member.name && attribute.type?.text !== member.type?.text) {
+      delete member.attribute;
+    }
+  });
+}
+
+// Preserve the shared CEM types and select standalone types only for framework declaration generators.
+function createStandaloneTypesManifest(customElementsManifest) {
+  const standaloneTypesManifest = structuredClone(customElementsManifest);
+  const standaloneInterfaceTypes = collectReachableStandaloneInterfaceTypes(standaloneTypesManifest);
+
+  standaloneTypesManifest.modules
+    .flatMap(module => module.declarations ?? [])
+    .filter(declaration => declaration.tagName)
+    .forEach(declaration => {
+      exposeDistinctFrameworkPropertyBindings(declaration);
+
+      [...(declaration.attributes ?? []), ...(declaration.members ?? [])].forEach(item => {
+        item.standaloneType = { text: expandStandaloneTypeText(item.type?.text, standaloneInterfaceTypes) };
+      });
+    });
+
+  return standaloneTypesManifest;
+}
+
+const standaloneTypesManifestCache = new WeakMap();
+
+function getStandaloneTypesManifest(customElementsManifest) {
+  if (!standaloneTypesManifestCache.has(customElementsManifest)) {
+    standaloneTypesManifestCache.set(customElementsManifest, createStandaloneTypesManifest(customElementsManifest));
+  }
+
+  return standaloneTypesManifestCache.get(customElementsManifest);
+}
+
+function withStandaloneTypes(plugin) {
+  return {
+    ...plugin,
+    packageLinkPhase({ customElementsManifest }) {
+      plugin.packageLinkPhase({ customElementsManifest: getStandaloneTypesManifest(customElementsManifest) });
+    }
+  };
+}
+
 function jsxTypesPlugin() {
-  return customElementJsxPlugin({
-    outdir: resolve('dist'),
-    fileName: 'custom-elements-jsx.d.ts',
-    globalEvents: `
+  return withStandaloneTypes(
+    customElementJsxPlugin({
+      outdir: resolve('dist'),
+      fileName: 'custom-elements-jsx.d.ts',
+      typesSrc: 'standaloneType',
+      globalEvents: `
       onClick?: (event: MouseEvent) => void;
       onKeyDown?: (event: KeyboardEvent) => void;
       onKeyUp?: (event: KeyboardEvent) => void;
@@ -615,14 +862,18 @@ function jsxTypesPlugin() {
       onPointerUp?: (event: PointerEvent) => void;
       onPointerMove?: (event: PointerEvent) => void;
     `
-  });
+    })
+  );
 }
 
 function vueTypesPlugin() {
-  return customElementVuejsPlugin({
-    outdir: resolve('dist'),
-    fileName: 'custom-elements-vue.d.ts'
-  });
+  return withStandaloneTypes(
+    customElementVuejsPlugin({
+      outdir: resolve('dist'),
+      fileName: 'custom-elements-vue.d.ts',
+      typesSrc: 'standaloneType'
+    })
+  );
 }
 
 function cssPropsPlugin() {
@@ -1392,6 +1643,8 @@ export default {
     const { config } = ts.readConfigFile(configFile, ts.sys.readFile);
     const { options } = ts.parseJsonConfigFileContent(config, ts.sys, process.cwd());
     const program = ts.createProgram(globs, options);
+    runtimeEnvironment.ts = ts;
+    runtimeEnvironment.program = program;
     runtimeEnvironment.typeChecker = program.getTypeChecker();
     return program.getSourceFiles().filter(sf => globs.find(glob => sf.fileName.includes(glob)));
   }


### PR DESCRIPTION
Fix invalid and misleading types in the generated custom-elements-jsx.d.ts and custom-elements-vue.d.ts by resolving generic and source-only types, distinguishing string-valued HTML attributes from element-valued JavaScript properties, preserving both framework bindings, and keeping the published declarations self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * More accurate generated JSX/Vue type declarations with concrete component property types.
  * Enhanced mixin and element-reference typing, including inlining referenced interfaces.
  * Pagination step-size option typing refined without changing defaults.
* **Tests / Chores**
  * Added strict type-checking via a new `test:types` task.
  * Improved menu keyboard-navigation test reliability by adjusting how items are queried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->