### PR TITLE
fix: attribute reflection fixes

### DIFF
--- a/projects/cli/src/mcp/ui/index.ts
+++ b/projects/cli/src/mcp/ui/index.ts
@@ -20,7 +20,7 @@ export const examplesRenderResource: UIResource = {
   mimeType: MCP_UI_MIME_TYPE,
   resourceUri: 'ui://elements/example-preview',
   description:
-    'Use this MCP app when an Elements example or template should be shown to the user. It renders validated nve-* HTML from examples_get or examples_render so users can inspect component layout, theme, and validation messages visually instead of reading markup only.',
+    'Use this MCP app when an NVIDIA Elements UI example or template should be shown to the user. It renders validated nve-* HTML from examples_get or examples_render so users can inspect component layout, theme, and validation messages visually instead of reading markup only.',
   getHtml: () => examplesRenderHtml
 };
 

--- a/projects/core/.visual/tabs-group.layout-end.png
+++ b/projects/core/.visual/tabs-group.layout-end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbac2cd3c2b422b4a213354b9e5a5df8d701d51d0bc7ab28f9aa7e2b3732272d
-size 2252
+oid sha256:ba7e7e9fcab6751d1a05cdfcf7b668a9e99087543789076ad398c24c2ba2a205
+size 9436

--- a/projects/core/src/accordion/accordion.test.lighthouse.ts
+++ b/projects/core/src/accordion/accordion.test.lighthouse.ts
@@ -23,6 +23,6 @@ describe('accordion lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(22.7);
+    expect(report.payload.javascript.kb).toBeLessThan(22.9);
   });
 });

--- a/projects/core/src/alert/alert.test.lighthouse.ts
+++ b/projects/core/src/alert/alert.test.lighthouse.ts
@@ -16,7 +16,7 @@ describe('alert lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(23.4);
+    expect(report.payload.javascript.kb).toBeLessThan(23.6);
   });
 
   test('alert-group should meet lighthouse benchmarks', async () => {
@@ -33,6 +33,6 @@ describe('alert lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(23.4);
+    expect(report.payload.javascript.kb).toBeLessThan(23.6);
   });
 });

--- a/projects/core/src/button/button.test.lighthouse.ts
+++ b/projects/core/src/button/button.test.lighthouse.ts
@@ -18,6 +18,6 @@ describe('button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(14.3);
+    expect(report.payload.javascript.kb).toBeLessThan(14.4);
   });
 });

--- a/projects/core/src/chat-message/chat-message.test.lighthouse.ts
+++ b/projects/core/src/chat-message/chat-message.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(14.3);
+    expect(report.payload.javascript.kb).toBeLessThan(14.4);
   });
 });

--- a/projects/core/src/color/color.test.lighthouse.ts
+++ b/projects/core/src/color/color.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('color lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(26.1);
+    expect(report.payload.javascript.kb).toBeLessThan(26.3);
   });
 });

--- a/projects/core/src/combobox/combobox.test.lighthouse.ts
+++ b/projects/core/src/combobox/combobox.test.lighthouse.ts
@@ -25,7 +25,7 @@ describe('combobox lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(36.3);
+    expect(report.payload.javascript.kb).toBeLessThan(36.4);
   });
 
   test('combobox multi select with large dataset should meet lighthouse benchmarks', async () => {

--- a/projects/core/src/copy-button/copy-button.test.lighthouse.ts
+++ b/projects/core/src/copy-button/copy-button.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('copy-button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(26.2);
+    expect(report.payload.javascript.kb).toBeLessThan(26.4);
   });
 });

--- a/projects/core/src/datetime/datetime.test.lighthouse.ts
+++ b/projects/core/src/datetime/datetime.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('datetime lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.7);
+    expect(report.payload.javascript.kb).toBeLessThan(25.8);
   });
 });

--- a/projects/core/src/dialog/dialog.test.lighthouse.ts
+++ b/projects/core/src/dialog/dialog.test.lighthouse.ts
@@ -25,6 +25,6 @@ describe('dialog lighthouse report', () => {
     expect(report.scores.performance).toBeGreaterThan(97); // bfcache
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.1);
+    expect(report.payload.javascript.kb).toBeLessThan(25.3);
   });
 });

--- a/projects/core/src/dropdown-group/dropdown-group.test.lighthouse.ts
+++ b/projects/core/src/dropdown-group/dropdown-group.test.lighthouse.ts
@@ -29,6 +29,6 @@ describe('dropdown-group lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25);
+    expect(report.payload.javascript.kb).toBeLessThan(25.2);
   });
 });

--- a/projects/core/src/forms/button-form-control-usage.test.ts
+++ b/projects/core/src/forms/button-form-control-usage.test.ts
@@ -122,6 +122,38 @@ describe('ButtonFormControlMixin core usage', () => {
         expect(button._internals.ariaExpanded).toBe('true');
       });
 
+      it('should expose native invoker property and attribute pairings', async () => {
+        const button = await createButton(usage);
+        const commandTarget = getElement<HTMLElement>(fixture, '#target');
+        const interestTarget = document.createElement('div');
+        interestTarget.id = 'interest-target';
+        const popoverTarget = document.createElement('div');
+        popoverTarget.id = 'popover-target';
+        popoverTarget.popover = 'auto';
+        fixture.append(interestTarget, popoverTarget);
+
+        button.setAttribute('interestfor', interestTarget.id);
+        button.setAttribute('popovertarget', popoverTarget.id);
+        button.setAttribute('popovertargetaction', 'show');
+        await elementIsStable(button);
+
+        expect(button.commandForElement).toBe(commandTarget);
+        expect(button.interestForElement).toBe(interestTarget);
+        expect(button.popoverTargetElement).toBe(popoverTarget);
+        expect(button.popoverTargetAction).toBe('show');
+
+        button.commandForElement = commandTarget;
+        button.interestForElement = interestTarget;
+        button.popoverTargetElement = popoverTarget;
+        button.popoverTargetAction = 'hide';
+        await elementIsStable(button);
+
+        expect(button.getAttribute('commandfor')).toBe('');
+        expect(button.getAttribute('interestfor')).toBe('');
+        expect(button.getAttribute('popovertarget')).toBe('');
+        expect(button.getAttribute('popovertargetaction')).toBe('hide');
+      });
+
       it('should dispatch commands and suppress interaction while unavailable', async () => {
         const button = await createButton(usage);
         const target = getElement<HTMLElement>(fixture, '#target');

--- a/projects/core/src/forms/button-form-control-usage.test.ts
+++ b/projects/core/src/forms/button-form-control-usage.test.ts
@@ -99,7 +99,7 @@ describe('ButtonFormControlMixin core usage', () => {
         expect(button.tabIndex).toBe(-1);
 
         button.disabled = false;
-        button.readonly = true;
+        button.readOnly = true;
         await elementIsStable(button);
         expect(button.readOnly).toBe(true);
         expect(button.hasAttribute('readonly')).toBe(true);

--- a/projects/core/src/icon-button/icon-button.test.lighthouse.ts
+++ b/projects/core/src/icon-button/icon-button.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('icon-button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(19.6);
+    expect(report.payload.javascript.kb).toBeLessThan(19.8);
   });
 });

--- a/projects/core/src/index.test.lighthouse.ts
+++ b/projects/core/src/index.test.lighthouse.ts
@@ -15,7 +15,7 @@ describe('lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.requests['index.js'].kb).toBeLessThan(133.1);
+    expect(report.payload.javascript.requests['index.js'].kb).toBeLessThan(133.3);
 
     // if sudden drop in size, check vite bundle config and bundle demo to ensure side effects are properly preserved
     expect(report.payload.javascript.requests['index.js'].kb).toBeGreaterThan(120);

--- a/projects/core/src/menu/menu.test.lighthouse.ts
+++ b/projects/core/src/menu/menu.test.lighthouse.ts
@@ -21,6 +21,6 @@ describe('menu lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(16.1);
+    expect(report.payload.javascript.kb).toBeLessThan(16.3);
   });
 });

--- a/projects/core/src/month/month.test.lighthouse.ts
+++ b/projects/core/src/month/month.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('month lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.7);
+    expect(report.payload.javascript.kb).toBeLessThan(25.8);
   });
 });

--- a/projects/core/src/notification/notification.test.lighthouse.ts
+++ b/projects/core/src/notification/notification.test.lighthouse.ts
@@ -17,6 +17,6 @@ describe('notification lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.5);
+    expect(report.payload.javascript.kb).toBeLessThan(25.6);
   });
 });

--- a/projects/core/src/pagination/pagination.test.lighthouse.ts
+++ b/projects/core/src/pagination/pagination.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('pagination lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(38.6);
+    expect(report.payload.javascript.kb).toBeLessThan(38.7);
   });
 });

--- a/projects/core/src/panel/panel.test.lighthouse.ts
+++ b/projects/core/src/panel/panel.test.lighthouse.ts
@@ -27,6 +27,6 @@ describe('panel lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(21.6);
+    expect(report.payload.javascript.kb).toBeLessThan(21.8);
   });
 });

--- a/projects/core/src/password/password.test.lighthouse.ts
+++ b/projects/core/src/password/password.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('password lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.8);
+    expect(report.payload.javascript.kb).toBeLessThan(25.9);
   });
 });

--- a/projects/core/src/preferences-input/preferences-input.test.lighthouse.ts
+++ b/projects/core/src/preferences-input/preferences-input.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('preferences-input lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(32.7);
+    expect(report.payload.javascript.kb).toBeLessThan(32.9);
   });
 });

--- a/projects/core/src/search/search.test.lighthouse.ts
+++ b/projects/core/src/search/search.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('search lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.5);
+    expect(report.payload.javascript.kb).toBeLessThan(25.7);
   });
 });

--- a/projects/core/src/select/select.test.lighthouse.ts
+++ b/projects/core/src/select/select.test.lighthouse.ts
@@ -23,6 +23,6 @@ describe('select lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(34.8);
+    expect(report.payload.javascript.kb).toBeLessThan(34.9);
   });
 });

--- a/projects/core/src/sort-button/sort-button.test.lighthouse.ts
+++ b/projects/core/src/sort-button/sort-button.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('sort-button lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(18.9);
+    expect(report.payload.javascript.kb).toBeLessThan(19.1);
   });
 });

--- a/projects/core/src/steps/steps.test.lighthouse.ts
+++ b/projects/core/src/steps/steps.test.lighthouse.ts
@@ -20,6 +20,6 @@ describe('steps lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(23.9);
+    expect(report.payload.javascript.kb).toBeLessThan(24);
   });
 });

--- a/projects/core/src/tabs/tabs-group.css
+++ b/projects/core/src/tabs/tabs-group.css
@@ -4,6 +4,7 @@
 :host {
   --padding: var(--nve-ref-space-sm) 0 0 0;
   display: block;
+  width: 100%;
 }
 
 :host(:is([alignment='start'], [alignment='end'])) {

--- a/projects/core/src/tag/tag.test.lighthouse.ts
+++ b/projects/core/src/tag/tag.test.lighthouse.ts
@@ -16,6 +16,6 @@ describe('tag lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(18.7);
+    expect(report.payload.javascript.kb).toBeLessThan(18.9);
   });
 });

--- a/projects/core/src/time/time.test.lighthouse.ts
+++ b/projects/core/src/time/time.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('time lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.5);
+    expect(report.payload.javascript.kb).toBeLessThan(25.6);
   });
 });

--- a/projects/core/src/toast/toast.test.lighthouse.ts
+++ b/projects/core/src/toast/toast.test.lighthouse.ts
@@ -17,6 +17,6 @@ describe('toast lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(24.8);
+    expect(report.payload.javascript.kb).toBeLessThan(25);
   });
 });

--- a/projects/core/src/tree/tree.test.lighthouse.ts
+++ b/projects/core/src/tree/tree.test.lighthouse.ts
@@ -27,6 +27,6 @@ describe('tree lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(29.9);
+    expect(report.payload.javascript.kb).toBeLessThan(30);
   });
 });

--- a/projects/core/src/week/week.test.lighthouse.ts
+++ b/projects/core/src/week/week.test.lighthouse.ts
@@ -19,6 +19,6 @@ describe('week lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.kb).toBeLessThan(25.7);
+    expect(report.payload.javascript.kb).toBeLessThan(25.9);
   });
 });

--- a/projects/forms/src/internal/controllers/type-interest-invoker.controller.test.ts
+++ b/projects/forms/src/internal/controllers/type-interest-invoker.controller.test.ts
@@ -159,6 +159,55 @@ describe('InterestInvokerController', () => {
     expect(element.interestForElement).toBe(target);
   });
 
+  it('should re-resolve inferred targets when popovertarget changes', async () => {
+    fixture = await createFixture(html`
+      <interest-invoker-controller-test-element popovertarget="first"></interest-invoker-controller-test-element>
+      <div id="first" popover="hint"></div>
+      <div id="second" popover="hint"></div>
+    `);
+    const element = fixture.querySelector<InterestInvokerControllerTestElement>(
+      'interest-invoker-controller-test-element'
+    )!;
+    const first = fixture.querySelector<HTMLElement>('#first')!;
+    const second = fixture.querySelector<HTMLElement>('#second')!;
+    const firstDispatch = vi.spyOn(first, 'dispatchEvent');
+    const secondDispatch = vi.spyOn(second, 'dispatchEvent');
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    element.setAttribute('popovertarget', 'second');
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    element.dispatchEvent(new MouseEvent('mouseleave'));
+
+    expect(firstDispatch.mock.calls.map(([event]) => event.type)).toEqual(['interest']);
+    expect(secondDispatch.mock.calls.map(([event]) => event.type)).toEqual(['interest', 'loseinterest']);
+    expect(element.interestForElement).toBe(second);
+  });
+
+  it('should preserve explicitly assigned interest targets when popovertarget changes', async () => {
+    fixture = await createFixture(html`
+      <interest-invoker-controller-test-element popovertarget="first"></interest-invoker-controller-test-element>
+      <div id="first" popover="hint"></div>
+      <div id="second" popover="hint"></div>
+      <div id="explicit"></div>
+    `);
+    const element = fixture.querySelector<InterestInvokerControllerTestElement>(
+      'interest-invoker-controller-test-element'
+    )!;
+    const first = fixture.querySelector<HTMLElement>('#first')!;
+    const explicit = fixture.querySelector<HTMLElement>('#explicit')!;
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    expect(element.interestForElement).toBe(first);
+
+    const explicitInterest = untilEvent<InterestTestEvent>(explicit, 'interest');
+    element.interestForElement = explicit;
+    element.setAttribute('popovertarget', 'second');
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+
+    expect((await explicitInterest).source).toBe(element);
+    expect(element.interestForElement).toBe(explicit);
+  });
+
   it('should no-op for missing targets and after disconnect', async () => {
     fixture = await createFixture(
       html`<interest-invoker-controller-test-element interestfor="missing"></interest-invoker-controller-test-element>`

--- a/projects/forms/src/internal/controllers/type-interest-invoker.controller.ts
+++ b/projects/forms/src/internal/controllers/type-interest-invoker.controller.ts
@@ -12,6 +12,8 @@ type InterestInvokerHost = ReactiveElement & {
 };
 
 export class TypeInterestInvokerController<T extends InterestInvokerHost> implements ReactiveController {
+  #inferredInterestForElement: HTMLElement | null = null;
+
   constructor(private host: T) {
     this.host.addController(this);
   }
@@ -39,36 +41,66 @@ export class TypeInterestInvokerController<T extends InterestInvokerHost> implem
       return;
     }
 
-    this.#updateInterestForElement();
-    if (this.host.interestForElement) {
-      const interest = new Event('interest', { cancelable: true }) as InterestEvent;
-      interest.source = this.host;
-      this.host.interestForElement.dispatchEvent(interest);
-    }
+    this.#dispatchInterestEvent('interest');
   };
 
-  #onLoseInterest = () => {
-    this.#updateInterestForElement();
-    if (this.host.interestForElement) {
-      const event = new Event('loseinterest', { cancelable: true }) as InterestEvent;
-      event.source = this.host;
-      this.host.interestForElement.dispatchEvent(event);
-    }
-  };
+  #onLoseInterest = () => this.#dispatchInterestEvent('loseinterest');
 
-  #updateInterestForElement() {
+  #dispatchInterestEvent(type: 'interest' | 'loseinterest') {
+    const target = this.#getInterestForElement();
+    if (!target) {
+      return;
+    }
+
+    const event = new Event(type, { cancelable: true }) as InterestEvent;
+    event.source = this.host;
+    target.dispatchEvent(event);
+  }
+
+  #getInterestForElement() {
+    const explicitTarget = this.#getExplicitInterestForElement();
+    if (explicitTarget !== undefined) {
+      return explicitTarget;
+    }
+
+    const inferredTarget = this.#getHintPopoverTarget();
+    const previousTarget = this.#inferredInterestForElement;
+    this.#inferredInterestForElement = inferredTarget;
+    if (inferredTarget && this.host.interestForElement !== inferredTarget) {
+      this.host.interestForElement = inferredTarget;
+    } else if (!inferredTarget && previousTarget && this.host.interestForElement === previousTarget) {
+      this.host.interestForElement = null;
+    }
+    return inferredTarget;
+  }
+
+  #getExplicitInterestForElement(): HTMLElement | null | undefined {
     const interestForIdRef = this.host.getAttribute('interestfor');
-    if (interestForIdRef && !this.host.interestForElement) {
-      this.host.interestForElement =
-        getFlattenedDOMTree(this.host.getRootNode()).find(element => element.id === interestForIdRef) ?? null;
+    if (interestForIdRef) {
+      this.#inferredInterestForElement = null;
+      return this.#getElementById(interestForIdRef);
     }
 
-    const popoverTargetIdRef = this.host.getAttribute('popovertarget');
-    if (popoverTargetIdRef && !interestForIdRef) {
-      const target = getFlattenedDOMTree(this.host.getRootNode()).find(element => element.id === popoverTargetIdRef);
-      if (target && target.popover === 'hint') {
-        this.host.interestForElement = target;
-      }
+    const interestForElement = this.host.interestForElement;
+    if (!interestForElement || interestForElement === this.#inferredInterestForElement) {
+      return undefined;
     }
+
+    this.#inferredInterestForElement = null;
+    return interestForElement;
+  }
+
+  #getHintPopoverTarget() {
+    const popoverTarget = this.host.popoverTargetElement;
+    if (popoverTarget instanceof HTMLElement && popoverTarget.popover === 'hint') {
+      return popoverTarget;
+    }
+
+    const target = this.#getElementById(this.host.getAttribute('popovertarget'));
+    return target instanceof HTMLElement && target.popover === 'hint' ? target : null;
+  }
+
+  #getElementById(id: string | null) {
+    return id ? (getFlattenedDOMTree(this.host.getRootNode()).find(element => element.id === id) ?? null) : null;
   }
 }

--- a/projects/forms/src/internal/controllers/type-popover-trigger.controller.test.ts
+++ b/projects/forms/src/internal/controllers/type-popover-trigger.controller.test.ts
@@ -14,7 +14,6 @@ class PopoverTriggerControllerTestElement extends HTMLElement {
   interestForElement: HTMLElement | null = null;
   popoverTargetAction?: PopoverTargetAction;
   popoverTargetElement: HTMLElement | null = null;
-  popovertarget?: string;
   #controllers = new Set<ReactiveController>();
 
   constructor() {
@@ -58,7 +57,7 @@ describe('PopoverTriggerController', () => {
     const popover = fixture.querySelector<HTMLElement>('[popover]')!;
     const togglePopover = vi.spyOn(popover, 'togglePopover').mockImplementation(() => false);
 
-    element.popovertarget = 'popover';
+    element.setAttribute('popovertarget', 'popover');
     await emulateClick(element);
 
     expect(element.popoverTargetElement).toBe(popover);
@@ -101,12 +100,12 @@ describe('PopoverTriggerController', () => {
 
     element.interestForElement = tooltip;
     element.popoverTargetAction = 'show';
-    element.popovertarget = 'first';
+    element.setAttribute('popovertarget', 'first');
     await emulateClick(element);
     first.hidePopover();
 
     loseInterest.mockClear();
-    element.popovertarget = 'second';
+    element.setAttribute('popovertarget', 'second');
     await emulateClick(element);
 
     expect(element.popoverTargetElement).toBe(second);
@@ -249,7 +248,7 @@ describe('PopoverTriggerController', () => {
 
     Object.defineProperty(popover, 'anchor', { configurable: true, value: 'anchor' });
     element.interestForElement = tooltip;
-    element.popovertarget = 'popover';
+    element.setAttribute('popovertarget', 'popover');
     await emulateClick(element);
 
     expect(element.popoverTargetElement).toBe(popover);

--- a/projects/forms/src/internal/controllers/type-popover-trigger.controller.ts
+++ b/projects/forms/src/internal/controllers/type-popover-trigger.controller.ts
@@ -13,7 +13,6 @@ type PopoverTriggerHost = ReactiveElement & {
   interestForElement: HTMLElement | null;
   popoverTargetAction?: PopoverTargetAction;
   popoverTargetElement: HTMLElement | null;
-  popovertarget?: string;
 };
 
 export class TypePopoverTriggerController<T extends PopoverTriggerHost> implements ReactiveController {
@@ -35,7 +34,7 @@ export class TypePopoverTriggerController<T extends PopoverTriggerHost> implemen
     const popoverTargetElement = this.host.popoverTargetElement;
     const controllerResolvedTarget = popoverTargetElement === this.#resolvedPopoverTarget;
 
-    if (!this.host.popovertarget) {
+    if (!this.host.getAttribute('popovertarget')) {
       this.#resolvedPopoverTarget = undefined;
       if (controllerResolvedTarget) {
         this.host.popoverTargetElement = null;
@@ -50,7 +49,9 @@ export class TypePopoverTriggerController<T extends PopoverTriggerHost> implemen
     }
 
     const resolvedPopoverTarget =
-      getFlattenedDOMTree(this.host.getRootNode()).find(element => element.id === this.host.popovertarget) ?? null;
+      getFlattenedDOMTree(this.host.getRootNode()).find(
+        element => element.id === this.host.getAttribute('popovertarget')
+      ) ?? null;
     if (resolvedPopoverTarget !== popoverTargetElement) {
       this.host.popoverTargetElement = resolvedPopoverTarget;
     }

--- a/projects/forms/src/mixins/button.test.ts
+++ b/projects/forms/src/mixins/button.test.ts
@@ -552,24 +552,15 @@ describe('ButtonFormControlMixin', () => {
 
     it('should sync removable string attributes', async () => {
       submitButton.value = 'saved';
-      submitButton.popovertarget = 'popover';
-      submitButton.commandfor = 'command-target';
       submitButton.command = '--test';
-      submitButton.interestfor = 'interest-target';
       await elementIsStable(submitButton);
 
       submitButton.removeAttribute('value');
-      submitButton.removeAttribute('popovertarget');
-      submitButton.removeAttribute('commandfor');
       submitButton.removeAttribute('command');
-      submitButton.removeAttribute('interestfor');
       await elementIsStable(submitButton);
 
       expect(submitButton.value).toBeUndefined();
-      expect(submitButton.popovertarget).toBeUndefined();
-      expect(submitButton.commandfor).toBe(null);
       expect(submitButton.command).toBeUndefined();
-      expect(submitButton.interestfor).toBe(null);
     });
   });
 
@@ -751,6 +742,69 @@ describe('ButtonFormControlMixin', () => {
       expect((propertyCommand.mock.calls[0]?.[0] as CommandTestEvent).source).toBe(button);
     });
 
+    it('should reflect native target properties to their corresponding attributes', async () => {
+      fixture = await createFixture(html`
+        <button-form-control-mixin-test-element
+          commandfor="attribute-command"
+          interestfor="attribute-interest"
+          popovertarget="attribute-popover"
+          popovertargetaction="show"
+        ></button-form-control-mixin-test-element>
+        <div id="attribute-command"></div>
+        <div id="attribute-interest"></div>
+        <div id="attribute-popover" popover></div>
+        <div id="property-command"></div>
+        <div id="property-interest"></div>
+        <div id="property-popover" popover></div>
+      `);
+      button = fixture.querySelector<ButtonFormControlMixinTestElement>('button-form-control-mixin-test-element')!;
+      const attributeCommand = fixture.querySelector<HTMLElement>('#attribute-command')!;
+      const attributeInterest = fixture.querySelector<HTMLElement>('#attribute-interest')!;
+      const attributePopover = fixture.querySelector<HTMLElement>('#attribute-popover')!;
+      const propertyCommand = fixture.querySelector<HTMLElement>('#property-command')!;
+      const propertyInterest = fixture.querySelector<HTMLElement>('#property-interest')!;
+      const propertyPopover = fixture.querySelector<HTMLElement>('#property-popover')!;
+      await elementIsStable(button);
+
+      expect(button.commandForElement).toBe(attributeCommand);
+      expect(button.interestForElement).toBe(attributeInterest);
+      expect(button.popoverTargetElement).toBe(attributePopover);
+      expect(button.popoverTargetAction).toBe('show');
+
+      button.commandForElement = propertyCommand;
+      button.interestForElement = propertyInterest;
+      button.popoverTargetElement = propertyPopover;
+      button.popoverTargetAction = 'hide';
+      await elementIsStable(button);
+
+      expect(button.getAttribute('commandfor')).toBe('');
+      expect(button.getAttribute('interestfor')).toBe('');
+      expect(button.getAttribute('popovertarget')).toBe('');
+      expect(button.getAttribute('popovertargetaction')).toBe('hide');
+      expect(button.commandForElement).toBe(propertyCommand);
+      expect(button.interestForElement).toBe(propertyInterest);
+      expect(button.popoverTargetElement).toBe(propertyPopover);
+
+      button.setAttribute('commandfor', 'attribute-command');
+      button.setAttribute('interestfor', 'attribute-interest');
+      button.setAttribute('popovertarget', 'attribute-popover');
+      button.setAttribute('popovertargetaction', 'invalid');
+      await elementIsStable(button);
+
+      expect(button.commandForElement).toBe(attributeCommand);
+      expect(button.interestForElement).toBe(attributeInterest);
+      expect(button.popoverTargetElement).toBe(attributePopover);
+      expect(button.popoverTargetAction).toBe('toggle');
+
+      button.commandForElement = null;
+      button.interestForElement = null;
+      button.popoverTargetElement = null;
+
+      expect(button.hasAttribute('commandfor')).toBe(false);
+      expect(button.hasAttribute('interestfor')).toBe(false);
+      expect(button.hasAttribute('popovertarget')).toBe(false);
+    });
+
     it('should no-op command dispatch when clicks are default-prevented, disabled, readonly, or commandless', async () => {
       fixture = await createFixture(html`
         <button-form-control-mixin-test-element command="--test" commandfor="target"></button-form-control-mixin-test-element>
@@ -860,7 +914,7 @@ describe('ButtonFormControlMixin', () => {
       emulateClick(button);
       first.hidePopover();
 
-      button.popovertarget = 'second';
+      button.setAttribute('popovertarget', 'second');
       await elementIsStable(button);
       emulateClick(button);
 

--- a/projects/forms/src/mixins/button.ts
+++ b/projects/forms/src/mixins/button.ts
@@ -17,6 +17,7 @@ import { StateSelectedController } from '../internal/controllers/state-selected.
 import type { ReactiveController } from '../internal/controllers/types.js';
 import {
   attachInternals,
+  getFlattenedDOMTree,
   getStringValue,
   hasAttributeValue,
   isFormElement,
@@ -51,6 +52,14 @@ interface StringStateOptions {
   reflect?: boolean;
 }
 
+const ELEMENT_TARGET_PROPERTIES = {
+  commandfor: 'commandForElement',
+  interestfor: 'interestForElement',
+  popovertarget: 'popoverTargetElement'
+} as const;
+type ElementTargetAttribute = keyof typeof ELEMENT_TARGET_PROPERTIES;
+type ElementTargetProperty = (typeof ELEMENT_TARGET_PROPERTIES)[ElementTargetAttribute];
+
 type ButtonFormControlConstructor<TBase extends Constructor> = new (
   ...args: ConstructorParameters<TBase>
 ) => InstanceType<TBase> & ButtonFormControlMixinInstance;
@@ -70,20 +79,19 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
     static formAssociated = true;
 
     #command: string | undefined;
-    #commandForElement: HTMLElement | null = null;
-    #commandfor: string | null = null;
     #current: CurrentState | undefined;
     #disabled = false;
+    #elementTargets: Record<ElementTargetProperty, HTMLElement | null> = {
+      commandForElement: null,
+      interestForElement: null,
+      popoverTargetElement: null
+    };
     #expanded: boolean | undefined;
     #form: string | HTMLFormElement | null = null;
     #hasConnected = false;
-    #interestForElement: HTMLElement | null = null;
-    #interestfor: string | null = null;
     #name: string | undefined;
     #pendingAttributeReflections = new Map<string, string | null>();
     #popoverTargetAction: PopoverTargetAction | undefined;
-    #popoverTargetElement: HTMLElement | null = null;
-    #popovertarget: string | undefined;
     #pressed: boolean | undefined;
     #readOnly = false;
     #selected: boolean | undefined;
@@ -220,26 +228,17 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
     }
 
     get popoverTargetElement(): HTMLElement | null {
-      return this.#popoverTargetElement;
+      return this.#getElementTarget('popovertarget');
     }
 
     set popoverTargetElement(value: HTMLElement | null) {
-      const oldValue = this.#popoverTargetElement;
-      this.#popoverTargetElement = value;
-      this.#requestHostUpdate('popoverTargetElement', oldValue);
-      this.#queueBehaviorSync();
-    }
-
-    get popovertarget(): string {
-      return this.#popovertarget as string;
-    }
-
-    set popovertarget(value: string | unknown) {
-      this.#setStringState({ property: 'popovertarget', value });
+      this.#setElementTarget('popovertarget', value);
     }
 
     get popoverTargetAction(): PopoverTargetAction {
-      return this.#popoverTargetAction as PopoverTargetAction;
+      return this.#popoverTargetAction === 'show' || this.#popoverTargetAction === 'hide'
+        ? this.#popoverTargetAction
+        : 'toggle';
     }
 
     set popoverTargetAction(value: PopoverTargetAction | unknown) {
@@ -247,22 +246,11 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
     }
 
     get commandForElement(): HTMLElement | null {
-      return this.#commandForElement;
+      return this.#getElementTarget('commandfor');
     }
 
     set commandForElement(value: HTMLElement | null) {
-      const oldValue = this.#commandForElement;
-      this.#commandForElement = value;
-      this.#requestHostUpdate('commandForElement', oldValue);
-      this.#queueBehaviorSync();
-    }
-
-    get commandfor(): string | null {
-      return this.#commandfor;
-    }
-
-    set commandfor(value: string | null | unknown) {
-      this.#setStringState({ property: 'commandfor', value });
+      this.#setElementTarget('commandfor', value);
     }
 
     get command(): string {
@@ -274,22 +262,11 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
     }
 
     get interestForElement(): HTMLElement | null {
-      return this.#interestForElement;
+      return this.#getElementTarget('interestfor');
     }
 
     set interestForElement(value: HTMLElement | null) {
-      const oldValue = this.#interestForElement;
-      this.#interestForElement = value;
-      this.#requestHostUpdate('interestForElement', oldValue);
-      this.#queueBehaviorSync();
-    }
-
-    get interestfor(): string | null {
-      return this.#interestfor;
-    }
-
-    set interestfor(value: string | null | unknown) {
-      this.#setStringState({ property: 'interestfor', value });
+      this.#setElementTarget('interestfor', value);
     }
 
     protected _controllers?: Set<ReactiveController>;
@@ -345,6 +322,7 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
       }
 
       this.#handleBooleanAttributeChange(name, newValue);
+      this.#handleElementTargetAttributeChange(name, oldValue);
       this.#handleStringAttributeChange(name, oldValue, newValue);
     }
 
@@ -376,6 +354,10 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
     }
 
     #handleStringAttributeChange(name: string, oldValue: string | null, newValue: string | null) {
+      if (name === 'commandfor' || name === 'interestfor' || name === 'popovertarget') {
+        return;
+      }
+
       if (name === 'form') {
         if (!(isFormElement(this.#form) && newValue === null)) {
           this.#form = newValue;
@@ -385,9 +367,44 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
 
       if (name === 'popovertargetaction') {
         this.#setStringState({ property: 'popoverTargetAction', value: newValue, reflect: false });
+        return;
       }
 
       this.#setStringState({ property: name, value: newValue, reflect: false });
+    }
+
+    #handleElementTargetAttributeChange(name: string, oldValue: string | null) {
+      const property = ELEMENT_TARGET_PROPERTIES[name as ElementTargetAttribute];
+      if (!property) {
+        return;
+      }
+
+      const oldTarget = this.#elementTargets[property] ?? this.#getElementById(oldValue);
+      this.#elementTargets[property] = null;
+      this.#requestHostUpdate(property, oldTarget);
+      this.#queueBehaviorSync();
+    }
+
+    #getElementTarget(attribute: ElementTargetAttribute) {
+      return (
+        this.#elementTargets[ELEMENT_TARGET_PROPERTIES[attribute]] ?? this.#getElementById(this.getAttribute(attribute))
+      );
+    }
+
+    #getElementById(id: string | null) {
+      return id ? (getFlattenedDOMTree(this.getRootNode()).find(element => element.id === id) ?? null) : null;
+    }
+
+    #setElementTarget(attribute: ElementTargetAttribute, value: HTMLElement | null) {
+      const property = ELEMENT_TARGET_PROPERTIES[attribute];
+      const oldValue = this[property];
+      if (oldValue === value && hasAttributeValue(this, attribute, value ? '' : null)) {
+        return;
+      }
+      setAttributeValue(this, attribute, value ? '' : null);
+      this.#elementTargets[property] = value;
+      this.#requestHostUpdate(property, oldValue);
+      this.#queueBehaviorSync();
     }
 
     #setBooleanState({ property, value, reflect, attribute = property }: BooleanStateOptions) {
@@ -446,12 +463,9 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
     #getStringValue(property: string) {
       return {
         command: this.#command,
-        commandfor: this.#commandfor,
         current: this.#current,
-        interestfor: this.#interestfor,
         name: this.#name,
         popoverTargetAction: this.#popoverTargetAction,
-        popovertarget: this.#popovertarget,
         type: this.#type,
         value: this.#value
       }[property];
@@ -460,12 +474,9 @@ export function ButtonFormControlMixin<TBase extends Constructor>(
     #setStringValue(property: string, value: string | null) {
       const setters: Record<string, () => void> = {
         command: () => (this.#command = value ?? undefined),
-        commandfor: () => (this.#commandfor = value),
         current: () => (this.#current = value as CurrentState),
-        interestfor: () => (this.#interestfor = value),
         name: () => (this.#name = value ?? undefined),
         popoverTargetAction: () => (this.#popoverTargetAction = value as PopoverTargetAction),
-        popovertarget: () => (this.#popovertarget = value ?? undefined),
         type: () => (this.#type = value as ButtonType),
         value: () => (this.#value = value ?? undefined)
       };

--- a/projects/forms/src/mixins/button.types.ts
+++ b/projects/forms/src/mixins/button.types.ts
@@ -89,16 +89,10 @@ export interface ButtonFormControlMixinInstance {
   /**
    * Establishes a relationship between a popover and its invoker button.
    * https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/popoverTargetElement
-   */
-  popoverTargetElement: HTMLElement | null;
-
-  /**
-   * The id reference of the element that receives the popover.
-   * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#popovertarget
    * @attr popovertarget
    * @reflect
    */
-  popovertarget: string;
+  popoverTargetElement: HTMLElement | null;
 
   /**
    * The popover target action to perform on the popover target element.

--- a/projects/internals/patterns/src/dashboard.examples.ts
+++ b/projects/internals/patterns/src/dashboard.examples.ts
@@ -328,4 +328,154 @@ export const ProjectBoard = {
       </main>
     </nve-page>
   `
-}
+};
+
+/**
+ * @summary Multi-route dashboard with top-level navigation and URL-synchronized tab views. Use for resource management pages where nested routes preserve context and browser history while keeping overview, activity, and access tasks close together.
+ * @tags pattern
+ */
+export const AdminRoutes = {
+  render() {
+    return html`
+<nve-page>
+  <nve-page-header slot="header">
+    <nve-logo slot="prefix" size="sm" color="brand-green">OP</nve-logo>
+    <h2 slot="prefix" nve-text="heading">Operations Admin</h2>
+    <nve-button selected container="flat"><a href="/admin/dashboard">Dashboard</a></nve-button>
+    <nve-button container="flat"><a href="/admin/teams">Teams</a></nve-button>
+    <nve-button container="flat"><a href="/admin/billing">Billing</a></nve-button>
+    <nve-icon-button interaction="emphasis" slot="suffix" size="sm">MK</nve-icon-button>
+  </nve-page-header>
+  <main nve-layout="column gap:lg pad:lg" style="max-width: 1300px;">
+    <div nve-layout="column gap:sm">
+      <p nve-text="label sm muted">Dashboard / Services / Inference API</p>
+      <h1 nve-text="heading lg">Inference API</h1>
+    </div>
+    <nve-tabs-group id="admin-route-tabs">
+      <nve-tabs>
+        <nve-tabs-item
+          selected
+          command="--toggle"
+          commandfor="admin-route-tabs"
+          value="overview"
+        >Overview</nve-tabs-item>
+        <nve-tabs-item
+          command="--toggle"
+          commandfor="admin-route-tabs"
+          value="activity"
+        >Activity</nve-tabs-item>
+        <nve-tabs-item
+          command="--toggle"
+          commandfor="admin-route-tabs"
+          value="access"
+        >Access</nve-tabs-item>
+      </nve-tabs>
+      <section slot="overview" nve-layout="column gap:lg">
+        <div nve-layout="grid gap:lg span-items:4 align:vertical-stretch">
+          <nve-card>
+            <nve-card-header><h2 nve-text="label muted">Requests today</h2></nve-card-header>
+            <nve-card-content>
+              <div nve-layout="column gap:xs">
+                <p nve-text="heading lg">2.4M</p>
+                <p nve-text="body sm muted">12% above the daily average</p>
+              </div>
+            </nve-card-content>
+          </nve-card>
+          <nve-card>
+            <nve-card-header><h2 nve-text="label muted">Success rate</h2></nve-card-header>
+            <nve-card-content>
+              <div nve-layout="column gap:xs">
+                <p nve-text="heading lg">99.98%</p>
+                <p nve-text="body sm muted">Within the 99.9% target</p>
+              </div>
+            </nve-card-content>
+          </nve-card>
+          <nve-card>
+            <nve-card-header><h2 nve-text="label muted">P95 latency</h2></nve-card-header>
+            <nve-card-content>
+              <div nve-layout="column gap:xs">
+                <p nve-text="heading lg">182 ms</p>
+                <p nve-text="body sm muted">18 ms below the alert threshold</p>
+              </div>
+            </nve-card-content>
+          </nve-card>
+        </div>
+        <nve-card>
+          <nve-card-header>
+            <div nve-layout="column gap:xs">
+              <h2 nve-text="heading sm">Service details</h2>
+              <p nve-text="body sm muted">Current production configuration.</p>
+            </div>
+          </nve-card-header>
+          <nve-card-content>
+            <dl nve-layout="grid gap:sm">
+              <dt nve-layout="span:4" nve-text="body muted medium">Region</dt>
+              <dd nve-layout="span:8" nve-text="body">us-central-1</dd>
+              <dt nve-layout="span:4" nve-text="body muted medium">Model</dt>
+              <dd nve-layout="span:8" nve-text="body">Llama 3.3 70B Instruct</dd>
+              <dt nve-layout="span:4" nve-text="body muted medium">Deployment</dt>
+              <dd nve-layout="span:8" nve-text="body">inference-api-v42</dd>
+            </dl>
+          </nve-card-content>
+        </nve-card>
+      </section>
+      <section slot="activity" nve-layout="column gap:md">
+        <nve-grid>
+          <nve-grid-header>
+            <nve-grid-column width="25%">Event</nve-grid-column>
+            <nve-grid-column width="25%">Actor</nve-grid-column>
+            <nve-grid-column width="25%">Time</nve-grid-column>
+            <nve-grid-column width="25%">Status</nve-grid-column>
+          </nve-grid-header>
+          <nve-grid-row>
+            <nve-grid-cell>Deployed inference-api-v42</nve-grid-cell>
+            <nve-grid-cell>Maya Kim</nve-grid-cell>
+            <nve-grid-cell>18 minutes ago</nve-grid-cell>
+            <nve-grid-cell><nve-badge status="success" container="flat">Completed</nve-badge></nve-grid-cell>
+          </nve-grid-row>
+          <nve-grid-row>
+            <nve-grid-cell>Updated autoscaling target</nve-grid-cell>
+            <nve-grid-cell>Jon Bell</nve-grid-cell>
+            <nve-grid-cell>2 hours ago</nve-grid-cell>
+            <nve-grid-cell><nve-badge status="finished" container="flat">Applied</nve-badge></nve-grid-cell>
+          </nve-grid-row>
+          <nve-grid-row>
+            <nve-grid-cell>Rotated service credentials</nve-grid-cell>
+            <nve-grid-cell>System</nve-grid-cell>
+            <nve-grid-cell>Yesterday</nve-grid-cell>
+            <nve-grid-cell><nve-badge status="finished" container="flat">Applied</nve-badge></nve-grid-cell>
+          </nve-grid-row>
+        </nve-grid>
+      </section>
+      <section slot="access" nve-layout="column gap:md">
+        <div nve-layout="grid gap:lg span-items:6 align:vertical-stretch">
+          <nve-card>
+            <nve-card-header>
+              <div nve-layout="row gap:sm align:space-between align:vertical-center">
+                <h3 nve-text="heading xs">Platform administrators</h3>
+                <nve-badge container="flat">Owner</nve-badge>
+              </div>
+            </nve-card-header>
+            <nve-card-content>
+              <p nve-text="body sm muted">12 members can deploy, configure, and manage access.</p>
+            </nve-card-content>
+          </nve-card>
+          <nve-card>
+            <nve-card-header>
+              <div nve-layout="row gap:sm align:space-between align:vertical-center">
+                <h3 nve-text="heading xs">ML operations</h3>
+                <nve-badge container="flat">Editor</nve-badge>
+              </div>
+            </nve-card-header>
+            <nve-card-content>
+              <p nve-text="body sm muted">28 members can deploy and update service configuration.</p>
+            </nve-card-content>
+          </nve-card>
+        </div>
+      </section>
+    </nve-tabs-group>
+  </main>
+</nve-page>
+    `
+  }
+};

--- a/projects/internals/tools/src/api/utils.ts
+++ b/projects/internals/tools/src/api/utils.ts
@@ -114,25 +114,44 @@ function getAPIDescriptionMarkdown(api: PartialAPIResult) {
   return wrapText(description).trim();
 }
 
-function getAttributeExampleContext(attribute: Attribute) {
-  if (attribute.name === 'nve-layout') {
-    return /* html */ `
+const NVE_LAYOUT_EXAMPLE = /* html */ `
+<!-- import path layout styles -->
+<style>
+  @import "@nvidia-elements/styles/layout.css";
+</style>
+
+<!-- inline row layout -->
 <section nve-layout="row gap:sm">
   <div></div>
   <div></div>
   <div></div>
 </section>
+
+<!-- stacked column layout -->
 <section nve-layout="column gap:sm">
   <div></div>
   <div></div>
   <div></div>
 </section>
+
+<!-- 12 column grid layout with 6 column span -->
 <section nve-layout="grid gap:sm span-items:6">
   <div>columns 1-6</div>
   <div>columns 7-12</div>
+</section>
+
+<!-- 12 column grid layout with variable column span -->
+<section nve-layout="grid gap:sm">
+  <div nve-layout="span:4">columns 1-4</div>
+  <div nve-layout="span:8">columns 5-12</div>
 </section>`;
-  } else if (attribute.name === 'nve-text') {
-    return /* html */ `
+
+const NVE_TEXT_EXAMPLE = /* html */ `
+<!-- import path typography styles -->
+<style>
+  @import "@nvidia-elements/styles/typography.css";
+</style>
+
 <h1 nve-text="heading">heading</h1>
 <p nve-text="body">body</p>
 <p nve-text="label">label</p>
@@ -152,6 +171,12 @@ function getAttributeExampleContext(attribute: Attribute) {
 <p nve-text="start">start</p>
 <p nve-text="center">center</p>
 <p nve-text="end">end</p>`;
+
+function getAttributeExampleContext(attribute: Attribute) {
+  if (attribute.name === 'nve-layout') {
+    return NVE_LAYOUT_EXAMPLE;
+  } else if (attribute.name === 'nve-text') {
+    return NVE_TEXT_EXAMPLE;
   }
   return attribute.example ?? '';
 }

--- a/projects/lint/src/eslint/rules/no-missing-popover-trigger.test.ts
+++ b/projects/lint/src/eslint/rules/no-missing-popover-trigger.test.ts
@@ -123,7 +123,7 @@ describe('noMissingPopoverTrigger', () => {
   });
 
   it('should report popover elements with template syntax content but no trigger', () => {
-    // Template syntax in content does not affect trigger requirement
+    // Content template syntax still requires a trigger
     tester.run('template syntax content requires trigger', rule, {
       valid: [],
       invalid: [
@@ -171,24 +171,30 @@ describe('noMissingPopoverTrigger', () => {
         // Template literal in popovertarget - popover should pass because trigger could match
         `<nve-button popovertarget="\${targetId}">Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`,
-        // Angular binding in popovertarget
-        `<nve-button [popovertarget]="targetId">Open</nve-button>
+        // Angular property binding for popovertarget
+        `<nve-button [popoverTargetElement]="target">Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`,
-        // Lit binding in popovertarget
-        `<nve-button .popovertarget="\${targetId}">Open</nve-button>
+        // Lit property binding for popovertarget
+        `<nve-button .popoverTargetElement="\${target}">Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`,
         // Template literal in commandfor
         `<nve-button commandfor="\${targetId}">Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`,
-        // Angular binding in commandfor
-        `<nve-button [commandfor]="targetId">Open</nve-button>
+        // Angular property binding for commandfor
+        `<nve-button [commandForElement]="target">Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`,
-        // Lit binding in commandfor
-        `<nve-button .commandfor="\${targetId}">Open</nve-button>
+        // Lit property binding for commandfor
+        `<nve-button .commandForElement="\${target}">Open</nve-button>
+         <nve-dropdown id="dropdown">Content</nve-dropdown>`,
+        // Lit property binding for interestfor
+        `<nve-button .interestForElement="\${target}">Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`,
         // JSX expression in popovertarget
-        `<nve-button popovertarget="{targetId}">Open</nve-button>
+        `<nve-button popovertarget={targetId}>Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`,
+        // JSX property binding for an HTMLElement ref
+        `<nve-button popoverTargetElement={popoverRef.current}>Open</nve-button>
+         <nve-dropdown ref={popoverRef} id="dropdown">Content</nve-dropdown>`,
         // Vue/Handlebars in popovertarget
         `<nve-button popovertarget="{{targetId}}">Open</nve-button>
          <nve-dropdown id="dropdown">Content</nve-dropdown>`

--- a/projects/lint/src/eslint/rules/no-missing-popover-trigger.ts
+++ b/projects/lint/src/eslint/rules/no-missing-popover-trigger.ts
@@ -21,8 +21,7 @@ const DATA_BINDING_PATTERNS = [
  * Check if an attribute value contains data binding syntax.
  */
 function hasDataBinding(value: string | undefined): boolean {
-  if (!value) return false;
-  return DATA_BINDING_PATTERNS.some(pattern => pattern.test(value));
+  return !!value && DATA_BINDING_PATTERNS.some(pattern => pattern.test(value));
 }
 
 /**
@@ -31,7 +30,8 @@ function hasDataBinding(value: string | undefined): boolean {
  */
 function findAttrWithBinding(
   node: HtmlNode,
-  attrName: string
+  attrName: string,
+  propertyName = attrName
 ): { attr: ReturnType<typeof findAttr>; hasBinding: boolean } {
   // Check for standard attribute
   const standard = findAttr(node, attrName);
@@ -39,22 +39,16 @@ function findAttrWithBinding(
     return { attr: standard, hasBinding: hasDataBinding(standard.value?.value) };
   }
 
-  // Check for Angular property binding: [attrName]
-  const angularAttr = findAttr(node, `[${attrName}]`);
-  if (angularAttr) {
-    return { attr: angularAttr, hasBinding: true };
+  const jsxProperty = findAttr(node, propertyName);
+  if (jsxProperty && hasDataBinding(jsxProperty.value?.value)) {
+    return { attr: jsxProperty, hasBinding: true };
   }
 
-  // Check for Lit property binding: .attrName
-  const litAttr = findAttr(node, `.${attrName}`);
-  if (litAttr) {
-    return { attr: litAttr, hasBinding: true };
-  }
-
-  // Check for Lit boolean-attribute binding: ?attrName
-  const litBoolAttr = findAttr(node, `?${attrName}`);
-  if (litBoolAttr) {
-    return { attr: litBoolAttr, hasBinding: true };
+  for (const name of [`[${propertyName}]`, `.${propertyName}`, `?${attrName}`]) {
+    const attr = findAttr(node, name);
+    if (attr) {
+      return { attr, hasBinding: true };
+    }
   }
 
   return { attr: undefined, hasBinding: false };
@@ -77,7 +71,11 @@ const POPOVER_ELEMENTS = [
 /**
  * Attributes that reference a popover target.
  */
-const TRIGGER_ATTRIBUTES = ['popovertarget', 'commandfor', 'interestfor'] as const;
+const TRIGGER_APIS = [
+  ['popovertarget', 'popoverTargetElement'],
+  ['commandfor', 'commandForElement'],
+  ['interestfor', 'interestForElement']
+] as const;
 
 interface PopoverNode {
   node: HtmlNode;
@@ -114,8 +112,8 @@ const rule = {
     let hasDynamicTrigger = false;
 
     function collectTriggerInfo(node: HtmlNode) {
-      for (const attr of TRIGGER_ATTRIBUTES) {
-        const { attr: found, hasBinding } = findAttrWithBinding(node, attr);
+      for (const [attribute, property] of TRIGGER_APIS) {
+        const { attr: found, hasBinding } = findAttrWithBinding(node, attribute, property);
         if (!found) continue;
         if (hasBinding) {
           hasDynamicTrigger = true;

--- a/projects/site/src/docs/skills/index.md
+++ b/projects/site/src/docs/skills/index.md
@@ -1,7 +1,7 @@
 ---
 {
   title: 'Skills',
-  description: 'Use NVIDIA Elements skills to give AI agents persistent project context, workflow guidance, and access to Elements UI authoring practices.',
+  description: 'NVIDIA skills to give AI agents persistent project context, workflow guidance, and access to NVIDIA Elements UI authoring practices.',
   layout: 'docs.11ty.js'
 }
 ---

--- a/projects/styles/build/metadata.js
+++ b/projects/styles/build/metadata.js
@@ -43,9 +43,11 @@ async function generateGlobalAttributes(files, attributes) {
   for (const [attribute, values] of Object.entries(utilityAttributes)) {
     let description = '';
     if (attribute === 'nve-layout') {
-      description = 'Layout utility for native HTML elements';
+      description =
+        'Layout utility for native HTML elements. Apply only to native HTML elements, not nve-* custom elements.';
     } else if (attribute === 'nve-text') {
-      description = 'Typography style utility for native HTML elements';
+      description =
+        'Typography style utility for native HTML elements. Apply only to native HTML elements, not nve-* custom elements.';
     } else if (attribute === 'nve-display') {
       description = 'Display utility for native HTML elements';
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buttons now coordinate command/interest/popover targeting via element-based properties with consistent attribute/property reflection.
  * `interest`/`loseinterest` dispatch updates automatically when the popover target changes, including proper handling of explicit `interestForElement`.
  * Validation now recognizes data bindings for `popoverTargetElement`, `commandForElement`, and `interestForElement`.
* **Breaking Changes**
  * Removed legacy string properties: `popovertarget`, `commandfor`, and `interestfor` (use the element-based counterparts).
* **Chores**
  * Loosened Lighthouse performance/payload thresholds and updated related tests.
* **Documentation / Style**
  * Updated skills page and `nve-layout`/`nve-text` attribute description wording; `tabs` host now spans full width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->