### PR TITLE
fix(lint): update no-missing-gap-space rule to allow gap-optional values

### DIFF
--- a/projects/core/eslint.config.js
+++ b/projects/core/eslint.config.js
@@ -30,6 +30,12 @@ export default [
     }
   },
   {
+    files: ['src/**/*.test.visual.ts'],
+    rules: {
+      '@nvidia-elements/lint/no-missing-gap-space': ['off']
+    }
+  },
+  {
     files: [
       'src/format-datetime/format-datetime.ts',
       'src/format-number/format-number.ts',

--- a/projects/core/src/toolbar/toolbar.css
+++ b/projects/core/src/toolbar/toolbar.css
@@ -117,6 +117,10 @@
   --border-bottom: 0;
 }
 
+slot {
+  min-height: inherit;
+}
+
 slot:not([name]) {
   gap: var(--gap);
   width: 100%;

--- a/projects/internals/patterns/src/editor.examples.ts
+++ b/projects/internals/patterns/src/editor.examples.ts
@@ -71,7 +71,7 @@ export const FileBrowser = {
     </nve-page-panel-content>
   </nve-page-panel>
 
-  <main nve-layout="column full">
+  <main nve-layout="column full gap:none">
     <nve-toolbar container="full">
       <nve-tabs behavior-select>
         <nve-tabs-item selected>lidar_config.py</nve-tabs-item>
@@ -169,7 +169,7 @@ export const DiffView = {
     <nve-button slot="suffix">Merge</nve-button>
   </nve-toolbar>
 
-  <main nve-layout="column">
+  <main nve-layout="column gap:none">
     <nve-toolbar container="full" style="--background: var(--nve-sys-layer-canvas-accent-background)">
       <div slot="prefix" nve-layout="row gap:sm align:vertical-center">
         <nve-icon-button icon-name="branch" size="sm" container="flat"></nve-icon-button>
@@ -345,7 +345,7 @@ export const ReadOnly = {
     </nve-page-panel-content>
   </nve-page-panel>
 
-  <main nve-layout="column" style="height: 100%">
+  <main nve-layout="column gap:none" style="height: 100%">
     <nve-toolbar container="full">
       <nve-tabs behavior-select>
         <nve-tabs-item selected>robot_config.yaml</nve-tabs-item>

--- a/projects/internals/patterns/src/templates.examples.ts
+++ b/projects/internals/patterns/src/templates.examples.ts
@@ -832,7 +832,7 @@ export const CodeEditor = {
       </nve-tree>
     </nve-page-panel-content>
   </nve-page-panel>
-  <main nve-layout="column full">
+  <main nve-layout="column full gap:none">
     <nve-toolbar container="full">
       <nve-tabs behavior-select>
         <nve-tabs-item selected>lidar_config.py</nve-tabs-item>

--- a/projects/internals/tools/src/playground/service.test.ts
+++ b/projects/internals/tools/src/playground/service.test.ts
@@ -17,10 +17,10 @@ describe('PlaygroundService', () => {
     const env = process.env.ELEMENTS_ENV;
     process.env.ELEMENTS_ENV = 'mcp';
     const result = await PlaygroundService.validate({
-      template: '<nve-button nve-layout="column">hello there</nve-button>'
+      template: '<nve-button nve-layout="column gap:sm">hello there</nve-button>'
     });
     expect(Array.isArray(result)).toBe(true);
-    expect(result.length).toBe(2);
+    expect(result.length).toBe(1);
     expect(result[0].message).toContain(
       'Unexpected use of restricted attribute "nve-layout" on <nve-button>. Remove the attribute.'
     );
@@ -28,10 +28,7 @@ describe('PlaygroundService', () => {
     expect(result[0].line).toBe(1);
     expect(result[0].column).toBe(13);
     expect(result[0].endLine).toBe(1);
-    expect(result[0].endColumn).toBe(32);
-    expect(result[1].message).toBe(
-      'Layout "column" is missing gap spacing. Add a gap value such as "xs", "sm", "md", "lg", "xl"'
-    );
+    expect(result[0].endColumn).toBe(39);
     expect((PlaygroundService.validate as ToolMethod<unknown>).metadata.name).toBe('validate');
     expect((PlaygroundService.validate as ToolMethod<unknown>).metadata.command).toBe('validate');
     expect((PlaygroundService.validate as ToolMethod<unknown>).metadata.description).toBe(
@@ -136,13 +133,13 @@ describe('PlaygroundService', () => {
       const createTool = tools.find(tool => tool.metadata.name === 'create');
 
       const result = (await createTool?.({
-        template: '<nve-button nve-layout="column">hello</nve-button>',
+        template: '<nve-button nve-layout="column gap:sm">hello</nve-button>',
         start: false
       })) as ToolOutput<{ message: string }[]>;
 
       expect(result.status).toBe('error');
       expect(result.message).toBe('Template validation failed');
-      expect(result.result).toHaveLength(2);
+      expect(result.result).toHaveLength(1);
       expect(result.result?.[0]?.message).toContain(
         'Unexpected use of restricted attribute "nve-layout" on <nve-button>. Remove the attribute.'
       );

--- a/projects/lint/README.md
+++ b/projects/lint/README.md
@@ -78,7 +78,7 @@ export default [
 | `@nvidia-elements/lint/no-invalid-event-listeners` | Disallow inline event handler attributes in HTML. | HTML | `error` |
 | `@nvidia-elements/lint/no-invalid-invoker-triggers` | Disallow use of invoker trigger attributes on non-button nve-* elements. | HTML | `error` |
 | `@nvidia-elements/lint/no-missing-control-label` | Require form controls to have an accessible label. | HTML | `error` |
-| `@nvidia-elements/lint/no-missing-gap-space` | Require gap spacing on row and column layouts. | HTML | `off` |
+| `@nvidia-elements/lint/no-missing-gap-space` | Require gap spacing on row, column, and grid layouts. | HTML | `error` |
 | `@nvidia-elements/lint/no-missing-icon-name` | Require icon elements to have an icon name attribute. | HTML | `error` |
 | `@nvidia-elements/lint/no-missing-popover-trigger` | Require popover elements to have a corresponding trigger element. | HTML | `error` |
 | `@nvidia-elements/lint/no-missing-slotted-elements` | Disallow use of missing slotted elements. | HTML | `error` |

--- a/projects/lint/src/eslint/configs/html.ts
+++ b/projects/lint/src/eslint/configs/html.ts
@@ -126,7 +126,7 @@ export const elementsHtmlConfig: Linter.Config = {
     '@nvidia-elements/lint/no-unstyled-typography': ['error'],
     '@nvidia-elements/lint/no-tailwind-classes': ['error'],
     '@nvidia-elements/lint/prefer-aria-label-in-compact-containers': ['error'],
-    '@nvidia-elements/lint/no-unexpected-style-customization': ['off'],
-    '@nvidia-elements/lint/no-missing-gap-space': ['off']
+    '@nvidia-elements/lint/no-missing-gap-space': ['error'],
+    '@nvidia-elements/lint/no-unexpected-style-customization': ['off']
   }
 };

--- a/projects/lint/src/eslint/internals/index.test.ts
+++ b/projects/lint/src/eslint/internals/index.test.ts
@@ -135,4 +135,14 @@ describe('lintPlaygroundTemplate', () => {
 
     expect(tailwindMessage?.severity).toBe('error');
   });
+
+  it('should apply missing gap checks to strict templates', async () => {
+    const missingGap = '<div nve-layout="row"><span>one</span><span>two</span></div>';
+    const explicitNoGap = '<div nve-layout="row gap:none"><span>one</span><span>two</span></div>';
+    const strictResult = await lintTemplate(missingGap, { strict: true });
+    const explicitNoGapResult = await lintTemplate(explicitNoGap, { strict: true });
+
+    expect(strictResult.find(message => message.id === 'missing-gap-space')?.severity).toBe('error');
+    expect(explicitNoGapResult.some(message => message.id === 'missing-gap-space')).toBe(false);
+  });
 });

--- a/projects/lint/src/eslint/rules/no-missing-gap-space.test.ts
+++ b/projects/lint/src/eslint/rules/no-missing-gap-space.test.ts
@@ -54,7 +54,7 @@ describe('noMissingGapSpace', () => {
     expect(noMissingGapSpace.meta.type).toBe('problem');
     expect(noMissingGapSpace.meta.hasSuggestions).toBe(true);
     expect(noMissingGapSpace.meta.docs).toBeDefined();
-    expect(noMissingGapSpace.meta.docs.description).toBe('Require gap spacing on row and column layouts.');
+    expect(noMissingGapSpace.meta.docs.description).toBe('Require gap spacing on row, column, and grid layouts.');
     expect(noMissingGapSpace.meta.docs.category).toBe('Best Practice');
     expect(noMissingGapSpace.meta.docs.recommended).toBe(true);
     expect(noMissingGapSpace.meta.docs.url).toContain('/docs/lint/');
@@ -93,7 +93,18 @@ describe('noMissingGapSpace', () => {
       valid: ['row', 'column', 'grid'].flatMap(layout =>
         GAP_OPTIONAL_VALUES.map(value => `<div nve-layout="${layout} ${value}"></div>`)
       ),
-      invalid: []
+      invalid: [
+        {
+          code: '<div nve-layout="grid"></div>',
+          errors: [
+            {
+              messageId: 'missing-gap-space',
+              data: { layout: 'grid' },
+              suggestions: gapSuggestions('grid')
+            }
+          ]
+        }
+      ]
     });
   });
 
@@ -122,6 +133,24 @@ describe('noMissingGapSpace', () => {
       invalid: [
         {
           code: '<div nve-layout="row"></div>',
+          errors: [
+            {
+              messageId: 'missing-gap-space',
+              data: { layout: 'row' },
+              suggestions: gapSuggestions('row')
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('should quote unquoted layout values in suggestions', () => {
+    tester.run('should quote unquoted layout values in suggestions', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: '<div nve-layout=row></div>',
           errors: [
             {
               messageId: 'missing-gap-space',

--- a/projects/lint/src/eslint/rules/no-missing-gap-space.test.ts
+++ b/projects/lint/src/eslint/rules/no-missing-gap-space.test.ts
@@ -10,6 +10,21 @@ import noMissingGapSpace from './no-missing-gap-space.js';
 const rule = noMissingGapSpace as unknown as JSRuleDefinition;
 
 const SUGGESTED_GAP_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'];
+const GAP_OPTIONAL_VALUES = [
+  'full',
+  'gap:none',
+  'align:center',
+  'align:horizontal-center',
+  'align:vertical-center',
+  'align:stretch',
+  'align:horizontal-stretch',
+  'align:vertical-stretch',
+  'align:left',
+  'align:right',
+  'align:space-around',
+  'align:space-between',
+  'align:space-evenly'
+];
 
 function gapSuggestions(layout: string) {
   return SUGGESTED_GAP_SIZES.map(size => ({
@@ -43,7 +58,7 @@ describe('noMissingGapSpace', () => {
     expect(noMissingGapSpace.meta.docs.category).toBe('Best Practice');
     expect(noMissingGapSpace.meta.docs.recommended).toBe(true);
     expect(noMissingGapSpace.meta.docs.url).toContain('/docs/lint/');
-    expect(noMissingGapSpace.meta.schema).toBeDefined();
+    expect(noMissingGapSpace.meta.schema).toEqual([]);
     expect(noMissingGapSpace.meta.messages).toBeDefined();
     expect(noMissingGapSpace.meta.messages['missing-gap-space']).toBe(
       `Layout "{{layout}}" is missing gap spacing. Add a gap value such as "${SUGGESTED_GAP_SIZES.join('", "')}"`
@@ -73,28 +88,11 @@ describe('noMissingGapSpace', () => {
     });
   });
 
-  it('should allow layouts with spacing alignment values', () => {
-    tester.run('should allow layouts with spacing alignment values', rule, {
-      valid: [
-        '<div nve-layout="row align:space-between"></div>',
-        '<div nve-layout="row align:space-around"></div>',
-        '<div nve-layout="row align:space-evenly"></div>',
-        '<div nve-layout="column align:space-between"></div>',
-        '<div nve-layout="column align:space-around"></div>',
-        '<div nve-layout="column align:space-evenly"></div>'
-      ],
-      invalid: []
-    });
-  });
-
-  it('should allow non-row/column layouts without gap', () => {
-    tester.run('should allow non-row/column layouts without gap', rule, {
-      valid: [
-        '<div nve-layout="grid"></div>',
-        '<div nve-layout="grid gap:md"></div>',
-        '<div nve-layout="full"></div>',
-        '<div nve-layout="grid span-items:4"></div>'
-      ],
+  it('should allow layouts with gap-optional values', () => {
+    tester.run('should allow layouts with gap-optional values', rule, {
+      valid: ['row', 'column', 'grid'].flatMap(layout =>
+        GAP_OPTIONAL_VALUES.map(value => `<div nve-layout="${layout} ${value}"></div>`)
+      ),
       invalid: []
     });
   });
@@ -154,17 +152,17 @@ describe('noMissingGapSpace', () => {
     });
   });
 
-  it('should report missing gap on row layout with other modifiers', () => {
-    tester.run('should report missing gap on row layout with modifiers', rule, {
+  it('should report missing gap on row layout with non-exempt alignment', () => {
+    tester.run('should report missing gap on row layout with non-exempt alignment', rule, {
       valid: [],
       invalid: [
         {
-          code: '<div nve-layout="row align:center"></div>',
+          code: '<div nve-layout="row align:top"></div>',
           errors: [
             {
               messageId: 'missing-gap-space',
-              data: { layout: 'row align:center' },
-              suggestions: gapSuggestions('row align:center')
+              data: { layout: 'row align:top' },
+              suggestions: gapSuggestions('row align:top')
             }
           ]
         }
@@ -177,12 +175,12 @@ describe('noMissingGapSpace', () => {
       valid: [],
       invalid: [
         {
-          code: '<div nve-layout="column full pad:md"></div>',
+          code: '<div nve-layout="column pad:md"></div>',
           errors: [
             {
               messageId: 'missing-gap-space',
-              data: { layout: 'column full pad:md' },
-              suggestions: gapSuggestions('column full pad:md')
+              data: { layout: 'column pad:md' },
+              suggestions: gapSuggestions('column pad:md')
             }
           ]
         }

--- a/projects/lint/src/eslint/rules/no-missing-gap-space.ts
+++ b/projects/lint/src/eslint/rules/no-missing-gap-space.ts
@@ -43,6 +43,11 @@ function reportGapViolation({
   layoutAttr: HtmlAttribute;
   value: string;
 }) {
+  const [startWrapper, endWrapper] =
+    layoutAttr.startWrapper && layoutAttr.endWrapper
+      ? [layoutAttr.startWrapper.value, layoutAttr.endWrapper.value]
+      : ['"', '"'];
+
   context.report({
     node: layoutAttr,
     messageId: 'missing-gap-space',
@@ -53,7 +58,7 @@ function reportGapViolation({
       fix: (fixer: Rule.RuleFixer) =>
         fixer.replaceText(
           layoutAttr as unknown as Rule.Node,
-          `nve-layout=${layoutAttr.startWrapper?.value}${suggestedLayout(value, size)}${layoutAttr.endWrapper?.value}`
+          `nve-layout=${startWrapper}${suggestedLayout(value, size)}${endWrapper}`
         )
     }))
   });
@@ -64,7 +69,7 @@ const rule = {
     type: 'problem' as const,
     hasSuggestions: true,
     docs: {
-      description: 'Require gap spacing on row and column layouts.',
+      description: 'Require gap spacing on row, column, and grid layouts.',
       category: 'Best Practice',
       recommended: true,
       url: `${__ELEMENTS_PAGES_BASE_URL__}/docs/lint/`

--- a/projects/lint/src/eslint/rules/no-missing-gap-space.ts
+++ b/projects/lint/src/eslint/rules/no-missing-gap-space.ts
@@ -5,14 +5,59 @@ import type { Rule } from 'eslint';
 import { createVisitors } from '@html-eslint/eslint-plugin/lib/rules/utils/visitors.js';
 import { findAttr } from '@html-eslint/eslint-plugin/lib/rules/utils/node.js';
 import { VALUE_BINDINGS } from '../internals/attributes.js';
-import type { HtmlTagNode } from '../rule-types.js';
+import type { HtmlAttribute, HtmlTagNode } from '../rule-types.js';
 
 declare const __ELEMENTS_PAGES_BASE_URL__: string;
-/** Spacing alignment values that manage their own distribution and override gap */
-const SPACING_ALIGNMENTS = ['align:space-around', 'align:space-between', 'align:space-evenly'];
+const GAP_OPTIONAL_VALUES = new Set([
+  'full',
+  'align:center',
+  'align:horizontal-center',
+  'align:vertical-center',
+  'align:stretch',
+  'align:horizontal-stretch',
+  'align:vertical-stretch',
+  'align:left',
+  'align:right',
+  'align:space-around',
+  'align:space-between',
+  'align:space-evenly'
+]);
 
 /** Context limited gap sizes to suggest as fixes */
 const SUGGESTED_GAP_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+function hasGapOptionalValue(values: string[]): boolean {
+  return values.some(value => GAP_OPTIONAL_VALUES.has(value));
+}
+
+function suggestedLayout(value: string, size: string): string {
+  return `${value} gap:${size}`;
+}
+
+function reportGapViolation({
+  context,
+  layoutAttr,
+  value
+}: {
+  context: Rule.RuleContext;
+  layoutAttr: HtmlAttribute;
+  value: string;
+}) {
+  context.report({
+    node: layoutAttr,
+    messageId: 'missing-gap-space',
+    data: { layout: value },
+    suggest: SUGGESTED_GAP_SIZES.map(size => ({
+      messageId: 'suggest-add-gap',
+      data: { size },
+      fix: (fixer: Rule.RuleFixer) =>
+        fixer.replaceText(
+          layoutAttr as unknown as Rule.Node,
+          `nve-layout=${layoutAttr.startWrapper?.value}${suggestedLayout(value, size)}${layoutAttr.endWrapper?.value}`
+        )
+    }))
+  });
+}
 
 const rule = {
   meta: {
@@ -36,36 +81,14 @@ const rule = {
         const layoutAttr = findAttr(node, 'nve-layout');
         if (!layoutAttr) return;
 
-        const value = layoutAttr.value?.value ?? '';
-
+        const value: string = layoutAttr.value?.value ?? '';
         if (VALUE_BINDINGS.some(binding => value.includes(binding))) return;
 
-        const segments = value.split(' ').filter((s: string) => s !== '');
-
-        const isRowOrColumn = segments.includes('row') || segments.includes('column');
-        if (!isRowOrColumn) return;
-
-        const hasGap = segments.some((s: string) => s.startsWith('gap:'));
-        if (hasGap) return;
-
-        const hasSpacingAlignment = segments.some((s: string) => SPACING_ALIGNMENTS.includes(s));
-        if (hasSpacingAlignment) return;
-
-        context.report({
-          node: layoutAttr,
-          messageId: 'missing-gap-space',
-          data: { layout: value },
-          suggest: SUGGESTED_GAP_SIZES.map(size => ({
-            messageId: 'suggest-add-gap',
-            data: { size },
-            fix: fixer => {
-              return fixer.replaceText(
-                layoutAttr,
-                `nve-layout=${layoutAttr.startWrapper.value}${value} gap:${size}${layoutAttr.endWrapper.value}`
-              );
-            }
-          }))
-        });
+        const values = value.split(/\s+/).filter(Boolean);
+        const isLayout = values.includes('row') || values.includes('column') || values.includes('grid');
+        const hasGap = values.some(segment => segment.startsWith('gap:'));
+        if (!isLayout || hasGap || hasGapOptionalValue(values)) return;
+        reportGapViolation({ context, layoutAttr, value });
       }
     });
   }

--- a/projects/site/src/_internal/search/search.ts
+++ b/projects/site/src/_internal/search/search.ts
@@ -471,7 +471,7 @@ export class DocsSearch extends LitElement {
 
   #renderSearchResult(result: SearchResult) {
     return html`
-      <a href="${this.baseUrl}${result.url}" nve-layout="column pad-top:xs">
+      <a href="${this.baseUrl}${result.url}" nve-layout="pad-top:xs">
         <div nve-layout="row gap:sm pad-top:xs pad-left:xs">
           <nve-icon name="${result.icon}" size="md" style="${result.style}"></nve-icon>
           <div nve-layout="column gap:xs">

--- a/projects/site/src/docs/foundations/themes/color.11ty.js
+++ b/projects/site/src/docs/foundations/themes/color.11ty.js
@@ -94,17 +94,17 @@ function getColorScale(color) {
     );
   }
   return /* html */ `
-  <div nve-layout="column pad-bottom:xl" docs-full-width>
+  <div nve-layout="pad-bottom:xl" docs-full-width>
     <h2 nve-text="body">${color.replace('ref-color-', '')}</h2>
-    <div nve-layout="row" style="width: 100%">
-      <div nve-layout="column" style="padding-top: 25px">${Array.from(Array(12).keys())
+    <div nve-layout="row full">
+      <div nve-layout="pad-top:xl">${Array.from(Array(12).keys())
         .map(
           i =>
             /* html */ `<p nve-text="body" nve-layout="column align:center pad:xs" style="height: 40px">${i + 1}00</p>`
         )
         .join('')}</div>
-      <div nve-layout="column" style="width: 100%"><p nve-text="body center" nve-layout="column align:center pad:xs" style="width: 100%">light</p><div nve-theme="root light" style="width: 100%" colors="">${tokens.join('')}</div></div>
-      <div nve-layout="column" style="width: 100%"><p nve-text="body center" nve-layout="column align:center pad:xs" style="width: 100%">dark</p><div nve-theme="root dark" style="width: 100%" colors="">${tokens.join('')}</div></div>
+      <div nve-layout="column full"><p nve-text="body center" nve-layout="column align:center pad:xs" style="width: 100%">light</p><div nve-theme="root light" style="width: 100%" colors="">${tokens.join('')}</div></div>
+      <div nve-layout="column full"><p nve-text="body center" nve-layout="column align:center pad:xs" style="width: 100%">dark</p><div nve-theme="root dark" style="width: 100%" colors="">${tokens.join('')}</div></div>
     </div>
   </div>`;
 }

--- a/projects/site/src/docs/lint/index.md
+++ b/projects/site/src/docs/lint/index.md
@@ -162,9 +162,9 @@ export default [
   </nve-grid-row>
   <nve-grid-row>
     <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-missing-gap-space</code></nve-grid-cell>
-    <nve-grid-cell>Require gap spacing on row and column layouts.</nve-grid-cell>
+    <nve-grid-cell>Require gap spacing on row, column, and grid layouts.</nve-grid-cell>
     <nve-grid-cell>HTML</nve-grid-cell>
-    <nve-grid-cell><code nve-text="code">off</code></nve-grid-cell>
+    <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
   </nve-grid-row>
   <nve-grid-row>
     <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-missing-icon-name</code></nve-grid-cell>

--- a/projects/styles/eslint.config.js
+++ b/projects/styles/eslint.config.js
@@ -1,4 +1,12 @@
 import { elementsRecommended } from '@nvidia-elements/lint/eslint';
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [...elementsRecommended];
+export default [
+  ...elementsRecommended,
+  {
+    files: ['src/**/*.test.visual.ts', 'src/**/*.examples.ts'],
+    rules: {
+      '@nvidia-elements/lint/no-missing-gap-space': ['off']
+    }
+  }
+];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spacing consistency across editor examples, code editor templates, search results, and color scale pages by applying `gap:none`/layout tweaks where needed.
  - Ensured slot elements inherit minimum height for more consistent toolbar/layout rendering.

- **Improvements**
  - Strengthened lint validation for missing `gap` in `nve-layout` (now includes `grid`).
  - Expanded gap-optional layouts (including `gap:none`) and refined the suggested correction behavior.

- **Documentation / Chores**
  - Updated lint rule docs and enabled the rule as an error, with exceptions for visual test/example files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->