### PR TITLE
chore(ci): enforce html custom data package contracts

### DIFF
--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -19,11 +19,6 @@
   "type": "module",
   "customElements": "dist/custom-elements.json",
   "contributes": {
-    "html": {
-      "customData": [
-        "./dist/data.html.json"
-      ]
-    },
     "snippets": [
       {
         "language": "html",

--- a/projects/internals/eslint/src/configs/json.js
+++ b/projects/internals/eslint/src/configs/json.js
@@ -1,5 +1,6 @@
 import json from '@eslint/json';
 import noUnpinnedDependencyRanges from '../local/no-unpinned-dependency-ranges.js';
+import requireHtmlCustomDataContract from '../local/require-html-custom-data-contract.js';
 
 const source = ['package.json'];
 const ignores = [
@@ -26,12 +27,14 @@ export const jsonConfig = [
       json,
       'local-json': {
         rules: {
-          'no-unpinned-dependency-ranges': noUnpinnedDependencyRanges
+          'no-unpinned-dependency-ranges': noUnpinnedDependencyRanges,
+          'require-html-custom-data-contract': requireHtmlCustomDataContract
         }
       }
     },
     rules: {
-      'local-json/no-unpinned-dependency-ranges': ['error']
+      'local-json/no-unpinned-dependency-ranges': ['error'],
+      'local-json/require-html-custom-data-contract': ['error']
     }
   }
 ];

--- a/projects/internals/eslint/src/local/require-html-custom-data-contract.js
+++ b/projects/internals/eslint/src/local/require-html-custom-data-contract.js
@@ -1,0 +1,86 @@
+const PACKAGE_SCOPE = '@nvidia-elements/';
+
+function getMember(object, name) {
+  return object?.members.find(member => member.name.value === name);
+}
+
+function getContributions(root) {
+  const contributes = getMember(root, 'contributes')?.value;
+  const html = contributes?.type === 'Object' ? getMember(contributes, 'html')?.value : undefined;
+
+  return html?.type === 'Object' ? getMember(html, 'customData') : undefined;
+}
+
+function isPackageRelativePath(packagePath) {
+  return packagePath.startsWith('./') && !packagePath.split('/').includes('..');
+}
+
+function getExportTargetPattern(target) {
+  return `^${target
+    .split('*')
+    .map(segment => segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*')}$`;
+}
+
+function matchesExportTarget(target, path) {
+  if (target.type === 'String') {
+    return new RegExp(getExportTargetPattern(target.value)).test(path);
+  }
+
+  if (target.type === 'Array') {
+    return target.elements.some(element => matchesExportTarget(element.value, path));
+  }
+
+  return target.type === 'Object' && target.members.some(member => matchesExportTarget(member.value, path));
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    name: 'require-html-custom-data-contract',
+    messages: {
+      'invalid-contribution': 'contributes.html.customData must be a non-empty array of package-relative paths.',
+      'missing-export': 'contributes.html.customData path "{{path}}" must be exposed by a package export.'
+    }
+  },
+  create(context) {
+    return {
+      Document(node) {
+        const root = node.body;
+        if (root.type !== 'Object') return;
+
+        const packageName = getMember(root, 'name')?.value;
+        if (packageName?.type !== 'String' || !packageName.value.startsWith(PACKAGE_SCOPE)) return;
+
+        const contributions = getContributions(root);
+        if (!contributions) return;
+
+        const exports = getMember(root, 'exports')?.value;
+        if (
+          contributions.value.type !== 'Array' ||
+          contributions.value.elements.length === 0 ||
+          contributions.value.elements.some(
+            element => element?.value?.type !== 'String' || !isPackageRelativePath(element.value.value)
+          )
+        ) {
+          context.report({ node: contributions.value, messageId: 'invalid-contribution' });
+          return;
+        }
+
+        for (const element of contributions.value.elements) {
+          const isExported =
+            exports?.type === 'Object' &&
+            exports.members.some(member => matchesExportTarget(member.value, element.value.value));
+          if (!isExported) {
+            context.report({
+              node: element.value,
+              messageId: 'missing-export',
+              data: { path: element.value.value }
+            });
+          }
+        }
+      }
+    };
+  }
+};

--- a/projects/internals/eslint/src/local/require-html-custom-data-contract.test.js
+++ b/projects/internals/eslint/src/local/require-html-custom-data-contract.test.js
@@ -1,0 +1,107 @@
+import { beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { RuleTester } from 'eslint';
+import json from '@eslint/json';
+import requireHtmlCustomDataContract from './require-html-custom-data-contract.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    plugins: {
+      json
+    },
+    language: 'json/json'
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(requireHtmlCustomDataContract.meta.type, 'problem');
+  assert.equal(requireHtmlCustomDataContract.meta.name, 'require-html-custom-data-contract');
+  assert.ok(requireHtmlCustomDataContract.meta.messages['missing-export']);
+});
+
+test('requires HTML Custom Data contributions to be exported', () => {
+  tester.run('require-html-custom-data-contract', requireHtmlCustomDataContract, {
+    valid: [
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": ["./dist/editor/custom-data.json"] } },
+          "exports": { "./editor-data.json": "./dist/editor/custom-data.json" }
+        }`
+      },
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": ["./dist/editor/custom-data.json"] } },
+          "exports": { "./editor-data.json": ["./dist/editor/custom-data.json"] }
+        }`
+      },
+      {
+        filename: 'package.json',
+        code: '{ "name": "@nvidia-elements/example" }'
+      },
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@internals/example",
+          "contributes": { "html": { "customData": ["./dist/editor/custom-data.json"] } }
+        }`
+      }
+    ],
+    invalid: [
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": ["./dist/data.html.json"] } }
+        }`,
+        errors: [{ messageId: 'missing-export' }]
+      },
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": [] } }
+        }`,
+        errors: [{ messageId: 'invalid-contribution' }]
+      },
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": ["./dist/data.html.json", 1] } }
+        }`,
+        errors: [{ messageId: 'invalid-contribution' }]
+      },
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": ["../dist/data.html.json"] } }
+        }`,
+        errors: [{ messageId: 'invalid-contribution' }]
+      },
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": ["/package/dist/data.html.json"] } }
+        }`,
+        errors: [{ messageId: 'invalid-contribution' }]
+      },
+      {
+        filename: 'package.json',
+        code: `{
+          "name": "@nvidia-elements/example",
+          "contributes": { "html": { "customData": ["./dist/editor/custom-data.json"] } },
+          "exports": { "./editor-data.json": "./dist/other-data.json" }
+        }`,
+        errors: [{ messageId: 'missing-export' }]
+      }
+    ]
+  });
+});

--- a/projects/internals/vite/package.json
+++ b/projects/internals/vite/package.json
@@ -7,7 +7,8 @@
     "playwright-lock": "./src/playwright/index.js"
   },
   "scripts": {
-    "ci": "wireit"
+    "ci": "wireit",
+    "test": "wireit"
   },
   "exports": {
     ".": "./src/index.js",
@@ -46,10 +47,20 @@
   },
   "wireit": {
     "ci": {
+      "dependencies": [
+        "test"
+      ],
       "files": [
         "src",
         "!src/playwright/locks"
       ]
+    },
+    "test": {
+      "command": "node --test 'src/**/*.test.js'",
+      "files": [
+        "src/**/*.js"
+      ],
+      "output": []
     }
   }
 }

--- a/projects/internals/vite/src/plugins/cem.js
+++ b/projects/internals/vite/src/plugins/cem.js
@@ -5,6 +5,65 @@ import { generateVsCodeCustomElementData } from 'custom-element-vs-code-integrat
 
 const resolve = rel => path.join(process.cwd(), rel);
 
+function getCustomDataPaths(packageJson) {
+  const customDataPaths = packageJson.contributes?.html?.customData;
+  if (customDataPaths === undefined) return [];
+
+  if (
+    !Array.isArray(customDataPaths) ||
+    customDataPaths.length === 0 ||
+    customDataPaths.some(customDataPath => typeof customDataPath !== 'string')
+  ) {
+    throw new Error(
+      `${packageJson.name}: contributes.html.customData must be a non-empty array of package-relative paths.`
+    );
+  }
+
+  return customDataPaths;
+}
+
+function isPackageRelativePath(packagePath) {
+  return packagePath.startsWith('./') && !packagePath.split('/').includes('..');
+}
+
+function getPackagePath(packageDirectory, packagePath) {
+  if (!isPackageRelativePath(packagePath)) return undefined;
+
+  const resolvedPath = path.resolve(packageDirectory, packagePath);
+  const pathFromPackage = path.relative(packageDirectory, resolvedPath);
+  return pathFromPackage.startsWith('..') || pathFromPackage === '' ? undefined : resolvedPath;
+}
+
+function hasManifestTags(manifest) {
+  return (manifest.modules ?? []).some(module => (module.declarations ?? []).some(declaration => declaration.tagName));
+}
+
+export function getCustomDataOutputs(packageJson, manifest, packageDirectory) {
+  const customDataPaths = getCustomDataPaths(packageJson);
+  const hasComponents = hasManifestTags(manifest);
+  const customDataOutputs = customDataPaths.map(customDataPath => {
+    const outputPath = getPackagePath(packageDirectory, customDataPath);
+    if (!outputPath) {
+      throw new Error(
+        `${packageJson.name}: contributes.html.customData path "${customDataPath}" must be package-relative.`
+      );
+    }
+
+    return {
+      outdir: path.dirname(outputPath),
+      htmlFileName: path.basename(outputPath)
+    };
+  });
+
+  if (hasComponents && customDataOutputs.length === 0) {
+    throw new Error(
+      `${packageJson.name}: Custom Elements Manifest declares tags but contributes.html.customData is missing.`
+    );
+  }
+
+  return hasComponents ? customDataOutputs : [];
+}
+
 function normalizeURL(value) {
   if (typeof value !== 'string') {
     return null;
@@ -45,9 +104,10 @@ export function cem() {
           : new URL('cem.config.mjs', import.meta.url).toString().replace('file://', '');
 
         const manifest = await cli({ argv: ['analyze', '--config', configPath, '--outdir', './dist'] });
-        const hasComponents = manifest.modules.flatMap(module => module.declarations).find(d => d.tagName);
+        const packageJson = JSON.parse(fs.readFileSync(resolve('./package.json'), 'utf8'));
+        const customDataOutputs = getCustomDataOutputs(packageJson, manifest, process.cwd());
 
-        if (hasComponents) {
+        if (customDataOutputs.length > 0) {
           // deep clone
           const vsCodeManifest = structuredClone(manifest);
           vsCodeManifest.modules.forEach(module => {
@@ -58,19 +118,20 @@ export function cem() {
               });
           });
 
-          generateVsCodeCustomElementData(vsCodeManifest, {
-            outdir: resolve('./dist'),
-            htmlFileName: 'data.html.json',
-            cssFileName: null,
-            referencesTemplate: (_name, tag) => {
-              const declaration = vsCodeManifest.modules
-                .flatMap(module => module.declarations)
-                .find(d => d.tagName === tag);
-              return Object.entries(declaration?.metadata ?? {}).flatMap(([name, value]) => {
-                const reference = generateVsCodeCustomElementDataReference(name, value);
-                return reference ? [reference] : [];
-              });
-            }
+          customDataOutputs.forEach(output => {
+            generateVsCodeCustomElementData(vsCodeManifest, {
+              ...output,
+              cssFileName: null,
+              referencesTemplate: (_name, tag) => {
+                const declaration = vsCodeManifest.modules
+                  .flatMap(module => module.declarations)
+                  .find(d => d.tagName === tag);
+                return Object.entries(declaration?.metadata ?? {}).flatMap(([name, value]) => {
+                  const reference = generateVsCodeCustomElementDataReference(name, value);
+                  return reference ? [reference] : [];
+                });
+              }
+            });
           });
         }
       }

--- a/projects/internals/vite/src/plugins/cem.test.js
+++ b/projects/internals/vite/src/plugins/cem.test.js
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getCustomDataOutputs } from './cem.js';
+
+const packageDirectory = '/package';
+
+function createManifest(tagNames = []) {
+  return {
+    modules: [
+      {
+        declarations: tagNames.map(tagName => ({ tagName }))
+      }
+    ]
+  };
+}
+
+function createPackageJson(customData) {
+  return {
+    name: '@nvidia-elements/example',
+    contributes: customData === undefined ? {} : { html: { customData } }
+  };
+}
+
+test('uses the declared Custom Data output path', () => {
+  assert.deepEqual(
+    getCustomDataOutputs(
+      createPackageJson(['./dist/editor/custom-data.json']),
+      createManifest(['nve-example']),
+      packageDirectory
+    ),
+    [
+      {
+        outdir: '/package/dist/editor',
+        htmlFileName: 'custom-data.json'
+      }
+    ]
+  );
+});
+
+test('requires a Custom Data contribution when the manifest declares tags', () => {
+  assert.throws(
+    () => getCustomDataOutputs(createPackageJson(), createManifest(['nve-example']), packageDirectory),
+    /Custom Elements Manifest declares tags/
+  );
+});
+
+test('rejects an empty Custom Data contribution', () => {
+  assert.throws(
+    () => getCustomDataOutputs(createPackageJson([]), createManifest(['nve-example']), packageDirectory),
+    /must be a non-empty array/
+  );
+});
+
+test('does not generate Custom Data when the manifest has no tags', () => {
+  assert.deepEqual(
+    getCustomDataOutputs(createPackageJson(['./dist/data.html.json']), createManifest(), packageDirectory),
+    []
+  );
+});
+
+test('does not generate Custom Data for sparse manifests', () => {
+  for (const manifest of [{}, { modules: [{}] }]) {
+    assert.deepEqual(
+      getCustomDataOutputs(createPackageJson(['./dist/data.html.json']), manifest, packageDirectory),
+      []
+    );
+  }
+});
+
+test('rejects traversal and absolute Custom Data paths before checking manifest tags', () => {
+  for (const manifest of [createManifest(), createManifest(['nve-example'])]) {
+    for (const customDataPath of ['../dist/data.html.json', '/package/dist/data.html.json']) {
+      assert.throws(
+        () => getCustomDataOutputs(createPackageJson([customDataPath]), manifest, packageDirectory),
+        /must be package-relative/
+      );
+    }
+  }
+});
+
+test('rejects malformed Custom Data contributions', () => {
+  assert.throws(
+    () => getCustomDataOutputs(createPackageJson(['./dist/data.html.json', 1]), createManifest(), packageDirectory),
+    /must be a non-empty array/
+  );
+});

--- a/projects/markdown/package.json
+++ b/projects/markdown/package.json
@@ -40,6 +40,7 @@
   "exports": {
     "./package.json": "./package.json",
     "./custom-elements.json": "./dist/custom-elements.json",
+    "./data.html.json": "./dist/data.html.json",
     "./*.examples.json": "./dist/*.examples.json",
     ".": {
       "types": "./dist/index.d.ts",

--- a/projects/media/package.json
+++ b/projects/media/package.json
@@ -14,11 +14,6 @@
   },
   "customElements": "dist/custom-elements.json",
   "contributes": {
-    "html": {
-      "customData": [
-        "./dist/data.html.json"
-      ]
-    },
     "snippets": [
       {
         "language": "html",


### PR DESCRIPTION
Fixes missing and stale HTML Custom Data package metadata across published Elements packages.
Adds per-package validation guardrails for Custom Data exports, packed artifacts, and CEM tag consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating Custom Elements data to multiple configured output paths.
  - Added a Markdown export for `data.html.json` → `dist/data.html.json`.
  - Introduced a `package:validate` CI step and added CI coverage for Vite tests.
- **Bug Fixes**
  - Added stricter validation for `contributes.html.customData`, including ensuring each entry is correctly exported.
  - VS Code Custom Elements data generation now runs only when tagged components exist.
  - Removed `html.customData` contributions from selected packages to match the validated contract.
- **Tests**
  - Added tests for Custom Elements data output derivation and manifest validation behavior, including the new ESLint rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->