### PR TITLE
feat(lint): add rule to limit excessive primary actions

### DIFF
--- a/projects/core/eslint.config.js
+++ b/projects/core/eslint.config.js
@@ -36,6 +36,12 @@ export default [
     }
   },
   {
+    files: ['src/button/button.test.visual.ts'],
+    rules: {
+      '@nvidia-elements/lint/no-excessive-primary-actions': ['off']
+    }
+  },
+  {
     files: [
       'src/format-datetime/format-datetime.ts',
       'src/format-number/format-number.ts',

--- a/projects/lint/README.md
+++ b/projects/lint/README.md
@@ -75,6 +75,7 @@ export default [
 | `@nvidia-elements/lint/no-deprecated-popover-attributes` | Disallow use of deprecated popover attributes. | HTML | `error` |
 | `@nvidia-elements/lint/no-deprecated-slots` | Disallow use of deprecated slot APIs. | HTML | `error` |
 | `@nvidia-elements/lint/no-deprecated-tags` | Disallow use of deprecated elements in HTML. | HTML | `error` |
+| `@nvidia-elements/lint/no-excessive-primary-actions` | Limit primary actions to two per page. | HTML | `error` |
 | `@nvidia-elements/lint/no-invalid-event-listeners` | Disallow inline event handler attributes in HTML. | HTML | `error` |
 | `@nvidia-elements/lint/no-invalid-invoker-triggers` | Disallow use of invoker trigger attributes on non-button nve-* elements. | HTML | `error` |
 | `@nvidia-elements/lint/no-missing-control-label` | Require form controls to have an accessible label. | HTML | `error` |

--- a/projects/lint/src/eslint/configs/html.ts
+++ b/projects/lint/src/eslint/configs/html.ts
@@ -16,6 +16,7 @@ import noDeprecatedGlobalAttributes from '../rules/no-deprecated-global-attribut
 import noRestrictedAttributes from '../rules/no-restricted-attributes.js';
 import noSlottedPopovers from '../rules/no-slotted-popovers.js';
 import noDeprecatedSlots from '../rules/no-deprecated-slots.js';
+import noExcessivePrimaryActions from '../rules/no-excessive-primary-actions.js';
 import noMissingSlottedElements from '../rules/no-missing-slotted-elements.js';
 import noMissingControlLabel from '../rules/no-missing-control-label.js';
 import noMissingIconName from '../rules/no-missing-icon-name.js';
@@ -71,6 +72,7 @@ export const elementsHtmlConfig: Linter.Config = {
         'no-deprecated-global-attribute-value': noDeprecatedGlobalAttributeValue,
         'no-deprecated-global-attributes': noDeprecatedGlobalAttributes,
         'no-deprecated-slots': noDeprecatedSlots,
+        'no-excessive-primary-actions': noExcessivePrimaryActions,
         'no-missing-slotted-elements': noMissingSlottedElements,
         'no-missing-control-label': noMissingControlLabel,
         'no-missing-icon-name': noMissingIconName,
@@ -106,6 +108,7 @@ export const elementsHtmlConfig: Linter.Config = {
     '@nvidia-elements/lint/no-deprecated-global-attribute-value': ['error'],
     '@nvidia-elements/lint/no-deprecated-global-attributes': ['error'],
     '@nvidia-elements/lint/no-deprecated-slots': ['error'],
+    '@nvidia-elements/lint/no-excessive-primary-actions': ['error'],
     '@nvidia-elements/lint/no-missing-slotted-elements': ['error'],
     '@nvidia-elements/lint/no-missing-control-label': ['error'],
     '@nvidia-elements/lint/no-missing-icon-name': ['error'],

--- a/projects/lint/src/eslint/internals/index.test.ts
+++ b/projects/lint/src/eslint/internals/index.test.ts
@@ -19,6 +19,17 @@ describe('lintPlaygroundTemplate', () => {
     expect(result).toEqual([]);
   });
 
+  it('should limit emphasis buttons per template', async () => {
+    const code = `
+      <nve-button interaction="emphasis">One</nve-button>
+      <nve-button interaction="emphasis">Two</nve-button>
+      <nve-button interaction="emphasis">Three</nve-button>
+    `;
+    const result = await lintTemplate(code, { strict: true });
+
+    expect(result.filter(message => message.id === 'excessive-primary-action')).toHaveLength(1);
+  });
+
   it('should detect restricted attributes on custom elements', async () => {
     const codeWithRestrictedAttribute = '<nve-button nve-layout="pad:md">Button</nve-button>';
     const result = await lintTemplate(codeWithRestrictedAttribute, { strict: true });

--- a/projects/lint/src/eslint/rules/no-excessive-primary-actions.test.ts
+++ b/projects/lint/src/eslint/rules/no-excessive-primary-actions.test.ts
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import type { JSRuleDefinition } from 'eslint';
+import htmlParser from '@html-eslint/parser';
+import noExcessivePrimaryActions from './no-excessive-primary-actions.js';
+
+const rule = noExcessivePrimaryActions as unknown as JSRuleDefinition;
+const error = {
+  messageId: 'excessive-primary-action' as const,
+  data: { max: '2' }
+};
+
+describe('noExcessivePrimaryActions', () => {
+  let tester: RuleTester;
+
+  beforeEach(() => {
+    tester = new RuleTester({
+      languageOptions: {
+        parser: htmlParser,
+        parserOptions: {
+          frontmatter: true
+        }
+      }
+    });
+  });
+
+  it('should define rule metadata', () => {
+    expect(noExcessivePrimaryActions.meta).toBeDefined();
+    expect(noExcessivePrimaryActions.meta.type).toBe('problem');
+    expect(noExcessivePrimaryActions.meta.docs).toBeDefined();
+    expect(noExcessivePrimaryActions.meta.docs.description).toBe('Limit primary actions to two per page.');
+    expect(noExcessivePrimaryActions.meta.docs.category).toBe('Best Practice');
+    expect(noExcessivePrimaryActions.meta.docs.recommended).toBe(true);
+    expect(noExcessivePrimaryActions.meta.docs.url).toContain('/docs/lint/');
+    expect(noExcessivePrimaryActions.meta.schema).toEqual([]);
+    expect(noExcessivePrimaryActions.meta.messages['excessive-primary-action']).toBe(
+      'Limit primary actions to {{max}} per page. Reserve interaction="emphasis" for primary calls to action.'
+    );
+  });
+
+  it('should allow no more than two emphasis buttons', () => {
+    tester.run('valid emphasis button count', rule, {
+      valid: [
+        '<nve-button>Default</nve-button>',
+        '<nve-button interaction="emphasis">Primary action</nve-button>',
+        `<nve-button interaction="emphasis">Primary action</nve-button>
+         <nve-button interaction="emphasis">Secondary action</nve-button>`,
+        `<nve-button interaction="emphasis">Primary action</nve-button>
+         <nve-button interaction="destructive">Delete</nve-button>
+         <nve-button interaction="neutral">Cancel</nve-button>`
+      ],
+      invalid: []
+    });
+  });
+
+  it('should ignore emphasis on elements other than nve-button', () => {
+    tester.run('non-button elements', rule, {
+      valid: [
+        `<nve-icon-button interaction="emphasis" icon-name="menu"></nve-icon-button>
+         <custom-button interaction="emphasis">Custom action</custom-button>
+         <button interaction="emphasis">Native action</button>`
+      ],
+      invalid: []
+    });
+  });
+
+  it('should ignore dynamic interaction values', () => {
+    tester.run('dynamic interaction values', rule, {
+      valid: [
+        `<nve-button interaction="\${interaction}">Lit attribute</nve-button>
+         <nve-button .interaction="\${interaction}">Lit property</nve-button>
+         <nve-button [interaction]="interaction">Angular property</nve-button>
+         <nve-button interaction="{{ interaction }}">Template binding</nve-button>
+         <nve-button interaction="{interaction}">JSX expression</nve-button>`
+      ],
+      invalid: []
+    });
+  });
+
+  it('should count separate tagged templates independently', () => {
+    const javascriptTester = new RuleTester({
+      languageOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      }
+    });
+
+    javascriptTester.run('separate tagged templates', rule, {
+      valid: [
+        `const first = html\`
+           <nve-button interaction="emphasis">One</nve-button>
+           <nve-button interaction="emphasis">Two</nve-button>
+         \`;
+         const second = html\`
+           <nve-button interaction="emphasis">Three</nve-button>
+           <nve-button interaction="emphasis">Four</nve-button>
+         \`;`
+      ],
+      invalid: [
+        {
+          code: `const template = html\`
+            <nve-button interaction="emphasis">One</nve-button>
+            <nve-button interaction="emphasis">Two</nve-button>
+            <nve-button interaction="emphasis">Three</nve-button>
+          \`;`,
+          errors: [error]
+        }
+      ]
+    });
+  });
+
+  it('should report the third emphasis button', () => {
+    tester.run('third emphasis button', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: `<nve-button interaction="emphasis">One</nve-button>
+                 <nve-button interaction="emphasis">Two</nve-button>
+                 <nve-button interaction="emphasis">Three</nve-button>`,
+          errors: [error]
+        }
+      ]
+    });
+  });
+
+  it('should report every emphasis button after the second', () => {
+    tester.run('multiple excessive emphasis buttons', rule, {
+      valid: [],
+      invalid: [
+        {
+          code: `<main>
+                   <nve-button interaction="emphasis">One</nve-button>
+                   <section>
+                     <nve-button interaction="emphasis">Two</nve-button>
+                     <nve-button interaction="emphasis">Three</nve-button>
+                   </section>
+                   <nve-button interaction="emphasis">Four</nve-button>
+                 </main>`,
+          errors: [error, error]
+        }
+      ]
+    });
+  });
+});

--- a/projects/lint/src/eslint/rules/no-excessive-primary-actions.ts
+++ b/projects/lint/src/eslint/rules/no-excessive-primary-actions.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Rule } from 'eslint';
+import { createVisitors } from '@html-eslint/eslint-plugin/lib/rules/utils/visitors.js';
+import { findAttr } from '@html-eslint/eslint-plugin/lib/rules/utils/node.js';
+import type { HtmlTagNode } from '../rule-types.js';
+
+declare const __ELEMENTS_PAGES_BASE_URL__: string;
+const MAX_EMPHASIS_BUTTONS = 2;
+
+const rule = {
+  meta: {
+    type: 'problem' as const,
+    docs: {
+      description: 'Limit primary actions to two per page.',
+      category: 'Best Practice',
+      recommended: true,
+      url: `${__ELEMENTS_PAGES_BASE_URL__}/docs/lint/`
+    },
+    schema: [],
+    messages: {
+      ['excessive-primary-action']:
+        'Limit primary actions to {{max}} per page. Reserve interaction="emphasis" for primary calls to action.'
+    }
+  },
+  create(context: Rule.RuleContext) {
+    let emphasisButtonCount = 0;
+
+    return createVisitors(context, {
+      Document() {
+        emphasisButtonCount = 0;
+      },
+      Tag(node: HtmlTagNode) {
+        if (node.name.toLowerCase() !== 'nve-button') {
+          return;
+        }
+
+        const interaction = findAttr(node, 'interaction');
+        if (interaction?.value?.value !== 'emphasis') {
+          return;
+        }
+
+        emphasisButtonCount += 1;
+        if (emphasisButtonCount <= MAX_EMPHASIS_BUTTONS) {
+          return;
+        }
+
+        context.report({
+          node: interaction,
+          messageId: 'excessive-primary-action',
+          data: { max: String(MAX_EMPHASIS_BUTTONS) }
+        });
+      }
+    });
+  }
+} as const;
+
+export default rule;

--- a/projects/site/src/_11ty/layouts/common.js
+++ b/projects/site/src/_11ty/layouts/common.js
@@ -32,7 +32,7 @@ export const renderBaseHead = data => {
   <meta name="author" content="${escapeAttr(AUTHOR_NAME)}">
   <link rel="canonical" href="${meta.canonicalUrl}">
   <link rel="alternate" type="text/plain" title="llms.txt" href="${DEPLOYED_SITE_URL}/llms.txt">
-  ${UPDATE_FEEDS.map(({ label, outputPath, type }) => `<link rel="alternate" type="application/${type}+xml" title="NVIDIA Elements updates (${label})" href="${getSiteUrl(outputPath)}">`).join('\n  ')}
+  ${UPDATE_FEEDS.map(({ label, outputPath, type }) => `<link rel="alternate" type="application/${type}+xml" title="NVIDIA Elements Updates (${label})" href="${getSiteUrl(outputPath)}">`).join('\n  ')}
   <link href="https://github.com/NVIDIA/elements" rel="me">
   <meta property="og:title" content="${escapeAttr(meta.title)}">
   <meta property="og:url" content="${meta.canonicalUrl}">

--- a/projects/site/src/_11ty/layouts/metadata.test.ts
+++ b/projects/site/src/_11ty/layouts/metadata.test.ts
@@ -397,10 +397,10 @@ describe('renderBaseHead', () => {
     });
 
     expect(html).toContain(
-      '<link rel="alternate" type="application/rss+xml" title="NVIDIA Elements updates (RSS)" href="https://nvidia.github.io/elements/feed.xml">'
+      '<link rel="alternate" type="application/rss+xml" title="NVIDIA Elements Updates (RSS)" href="https://nvidia.github.io/elements/feed.xml">'
     );
     expect(html).toContain(
-      '<link rel="alternate" type="application/atom+xml" title="NVIDIA Elements updates (Atom)" href="https://nvidia.github.io/elements/atom.xml">'
+      '<link rel="alternate" type="application/atom+xml" title="NVIDIA Elements Updates (Atom)" href="https://nvidia.github.io/elements/atom.xml">'
     );
   });
 });

--- a/projects/site/src/_11ty/plugins/updates-feed.js
+++ b/projects/site/src/_11ty/plugins/updates-feed.js
@@ -33,7 +33,7 @@ export const UPDATE_FEED_METADATA = {
   language: 'en',
   subtitle:
     'What’s new in the NVIDIA Elements Design System, including product updates, release highlights, and announcements.',
-  title: 'NVIDIA Elements updates'
+  title: 'NVIDIA Elements Updates'
 };
 
 export const RSS_FEED_TEMPLATE = `<?xml version="1.0" encoding="utf-8"?>

--- a/projects/site/src/docs/lint/index.md
+++ b/projects/site/src/docs/lint/index.md
@@ -143,6 +143,12 @@ export default [
     <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
   </nve-grid-row>
   <nve-grid-row>
+    <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-excessive-primary-actions</code></nve-grid-cell>
+    <nve-grid-cell>Limit primary actions to two per page.</nve-grid-cell>
+    <nve-grid-cell>HTML</nve-grid-cell>
+    <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
+  </nve-grid-row>
+  <nve-grid-row>
     <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-invalid-event-listeners</code></nve-grid-cell>
     <nve-grid-cell>Disallow inline event handler attributes in HTML.</nve-grid-cell>
     <nve-grid-cell>HTML</nve-grid-cell>


### PR DESCRIPTION
- Introduced a new ESLint rule `@nvidia-elements/lint/no-excessive-primary-actions` to restrict the use of emphasis buttons to a maximum of two per page.
- Updated ESLint configuration to include the new rule.
- Added tests for the new rule to ensure correct functionality.
- Updated documentation to reflect the new rule and its purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new ESLint rule that reports an error when a page contains more than two primary action `<nve-button interaction="emphasis">` elements.
  * Enabled the rule for HTML linting, with an exception for a specific visual button test.
* **Documentation**
  * Documented the new rule in the lint rules table (two-action limit, error severity).
* **Tests**
  * Added rule test coverage for valid/invalid counts, non-literal interactions, and separate template scopes.
  * Added an internal strict-mode lint test to confirm the diagnostic after the limit.
* **Chores**
  * Corrected capitalization in generated update feed titles and adjusted related metadata tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->