### PR TITLE
fix(styles): default line heights

### DIFF
--- a/projects/site/src/docs/foundations/typography.md
+++ b/projects/site/src/docs/foundations/typography.md
@@ -89,6 +89,10 @@ See the links below for specific integration patterns for the following framewor
 
 {% example '@nvidia-elements/styles/typography.examples.json' 'Headings' %}
 
+## Code
+
+{% example '@nvidia-elements/styles/typography.examples.json' 'Code' %}
+
 ## Size
 
 {% example '@nvidia-elements/styles/typography.examples.json' 'Size' %}

--- a/projects/styles/.visual/text-line-height-override.png
+++ b/projects/styles/.visual/text-line-height-override.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5872e037e01a81610ca3de0b0c87e46f448d9c5c5dd5c47da70e594e725c53a6
+size 2578

--- a/projects/styles/.visual/text-line-height.png
+++ b/projects/styles/.visual/text-line-height.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba89a5d1c49fa559867d1af008679129f2d63d2ea7fd500a83bc85927087dd85
+size 8874

--- a/projects/styles/src/index.test.lighthouse.ts
+++ b/projects/styles/src/index.test.lighthouse.ts
@@ -23,7 +23,7 @@ describe('lighthouse report', () => {
   });
 
   test('typography.css should remain within compressed bundle limits', async () => {
-    expect(report.payload.css.requests['typography.css']!.kb).toBeLessThan(1.65);
+    expect(report.payload.css.requests['typography.css']!.kb).toBeLessThan(1.85);
   });
 
   test('view-transitions.css should remain within compressed bundle limits', async () => {

--- a/projects/styles/src/typography.css
+++ b/projects/styles/src/typography.css
@@ -5,11 +5,19 @@
 [nve-text~='heading'],
 [nve-text~='body'],
 [nve-text~='label'],
-[nve-text~='list'],
-[nve-text~='list'] li {
+[nve-text~='link'],
+[nve-text~='list'] {
+  --_color: var(--nve-sys-text-color);
+  --_font-weight: var(--nve-ref-font-weight-regular);
+  --_font-size: initial;
+  --_line-height: initial;
+  --_text-decoration: initial;
   font-family: var(--nve-ref-font-family) !important;
-  font-weight: var(--nve-ref-font-weight-regular) !important;
-  color: var(--nve-sys-text-color) !important;
+  font-weight: var(--_font-weight) !important;
+  font-size: var(--_font-size) !important;
+  line-height: var(--_line-height) !important;
+  color: var(--_color) !important;
+  text-decoration: var(--_text-decoration) !important;
   white-space: initial;
   margin: 0;
 }
@@ -18,8 +26,7 @@
 [nve-text~='heading'],
 [nve-text~='body'],
 [nve-text~='label'],
-[nve-text~='link'],
-[nve-text~='code'] {
+[nve-text~='link'] {
   text-box: trim-both cap alphabetic;
   outline: var(--nve-debug-typography-outline, initial);
 }
@@ -31,7 +38,7 @@ body[nve-text],
 }
 
 @supports not (text-box: trim-both cap alphabetic) {
-  /* https://seek-oss.github.io/capsize/ (firefox) */
+  /* https://seek-oss.github.io/capsize/ (firefox, drop in v154) */
   [nve-text] {
     --_capsize-offset: -0.1818em;
   }
@@ -61,76 +68,127 @@ body[nve-text],
 }
 
 [nve-text~='display'] {
-  font-size: var(--nve-ref-font-size-1000) !important;
+  --_font-size: var(--nve-ref-font-size-1000);
+  --_line-height: var(--nve-ref-font-line-height-tight);
 
   &[nve-text~='xl'] {
-    font-size: var(--nve-ref-font-size-1200) !important;
+    --_font-size: var(--nve-ref-font-size-1200);
   }
 
   &[nve-text~='lg'] {
-    font-size: var(--nve-ref-font-size-1100) !important;
+    --_font-size: var(--nve-ref-font-size-1100);
   }
 
   &[nve-text~='sm'] {
-    font-size: var(--nve-ref-font-size-900) !important;
+    --_font-size: var(--nve-ref-font-size-900);
   }
 }
 
 [nve-text~='heading'] {
-  font-size: var(--nve-ref-font-size-400) !important;
+  --_font-size: var(--nve-ref-font-size-400);
+  --_line-height: var(--nve-ref-font-line-height-moderate);
 
   &[nve-text~='xl'] {
-    font-size: var(--nve-ref-font-size-600) !important;
+    --_font-size: var(--nve-ref-font-size-600);
+    --_line-height: var(--nve-ref-font-line-height-snug);
   }
 
   &[nve-text~='lg'] {
-    font-size: var(--nve-ref-font-size-500) !important;
+    --_font-size: var(--nve-ref-font-size-500);
+    --_line-height: var(--nve-ref-font-line-height-snug);
   }
 
   &[nve-text~='sm'] {
-    font-size: var(--nve-ref-font-size-300) !important;
+    --_font-size: var(--nve-ref-font-size-300);
   }
 
   &[nve-text~='xs'] {
-    font-size: var(--nve-ref-font-size-200) !important;
+    --_font-size: var(--nve-ref-font-size-200);
   }
 }
 
 [nve-text~='body'] {
-  font-size: var(--nve-ref-font-size-200) !important;
-  font-weight: var(--nve-ref-font-weight-regular) !important;
+  --_font-size: var(--nve-ref-font-size-200);
+  --_font-weight: var(--nve-ref-font-weight-regular);
+  --_line-height: var(--nve-ref-font-line-height-moderate);
 
   &[nve-text~='xl'] {
-    font-size: var(--nve-ref-font-size-400) !important;
+    --_font-size: var(--nve-ref-font-size-400);
+    --_line-height: var(--nve-ref-font-line-height-relaxed);
   }
 
   &[nve-text~='lg'] {
-    font-size: var(--nve-ref-font-size-300) !important;
+    --_font-size: var(--nve-ref-font-size-300);
+    --_line-height: var(--nve-ref-font-line-height-relaxed);
   }
 
   &[nve-text~='sm'] {
-    font-size: var(--nve-ref-font-size-100) !important;
+    --_font-size: var(--nve-ref-font-size-100);
   }
 }
 
 [nve-text~='label'] {
-  font-size: var(--nve-ref-font-size-200) !important;
-  font-weight: var(--nve-ref-font-weight-medium) !important;
+  --_font-size: var(--nve-ref-font-size-200);
+  --_font-weight: var(--nve-ref-font-weight-medium);
+  --_line-height: var(--nve-ref-font-line-height-moderate);
 
   &[nve-text~='xl'] {
-    font-size: var(--nve-ref-font-size-400) !important;
+    --_font-size: var(--nve-ref-font-size-400);
+    --_line-height: var(--nve-ref-font-line-height-tight);
   }
 
   &[nve-text~='lg'] {
-    font-size: var(--nve-ref-font-size-300) !important;
+    --_font-size: var(--nve-ref-font-size-300);
+    --_line-height: var(--nve-ref-font-line-height-snug);
   }
 
   &[nve-text~='sm'] {
-    font-size: var(--nve-ref-font-size-100) !important;
+    --_font-size: var(--nve-ref-font-size-100);
+  }
+}
+
+[nve-text~='link'] {
+  --_color: var(--nve-sys-text-link-color);
+  --_font-size: inherit;
+  --_font-weight: inherit;
+  --_line-height: inherit;
+  --_text-decoration: underline;
+
+  &[nve-text~='emphasis'] {
+    --_color: var(--nve-sys-text-link-emphasis-color);
+  }
+
+  &[nve-text~='disabled'] {
+    --_color: var(--nve-sys-text-link-disabled-color);
+  }
+
+  &:visited,
+  &[nve-text~='visited'] {
+    --_color: var(--nve-sys-text-link-visited-color);
+  }
+
+  &:hover,
+  &[nve-text~='hover'] {
+    --_color: var(--nve-sys-text-link-hover-color);
+  }
+
+  &:visited:not(:hover)[nve-text~='no-visit'] {
+    --_color: var(--nve-sys-text-link-color);
+  }
+
+  &[nve-text~='no-underline'] {
+    --_text-decoration: none;
+  }
+
+  &:focus-visible {
+    outline: Highlight solid 2px !important;
+    outline: 5px auto -webkit-focus-ring-color !important;
   }
 }
 
 [nve-text~='list'] {
+  --_font-size: inherit;
+  --_font-weight: inherit;
   margin: 0 !important;
   padding-block: 0 !important;
   padding-inline: var(--nve-ref-size-400) 0 !important;
@@ -145,176 +203,170 @@ body[nve-text],
   }
 }
 
-ul[nve-text~='nav'],
-ul[nve-text~='nav'] ul {
+ul[nve-text~='nav'] {
   padding: 0 !important;
   margin: 0 !important;
-}
 
-ul[nve-text~='nav'] li {
-  font-size: var(--nve-ref-font-size-200);
-  padding: 0;
-  list-style: none !important;
-  color: var(--nve-sys-text-muted-color) !important;
-  margin-block: 0 var(--nve-ref-space-sm) !important;
-  margin-inline: 0 !important;
-
-  > a {
-    text-decoration: none !important;
+  ul {
+    padding: 0 !important;
+    margin: 0 !important;
   }
 
-  > a:not(:hover) {
+  li {
+    font-size: var(--nve-ref-font-size-200);
+    padding: 0;
+    list-style: none !important;
     color: var(--nve-sys-text-muted-color) !important;
-  }
+    margin-block: 0 var(--nve-ref-space-sm) !important;
+    margin-inline: 0 !important;
 
-  > a[aria-current='page'] {
-    color: var(--nve-sys-text-link-hover-color) !important;
-    font-weight: var(--nve-ref-font-weight-semibold) !important;
-  }
-}
+    > a {
+      text-decoration: none !important;
+    }
 
-ul[nve-text~='nav'] ul li {
-  font-size: var(--nve-ref-font-size-100);
-  margin-block: 0 var(--nve-ref-space-sm) !important;
-  margin-inline: var(--nve-ref-space-lg) 0 !important;
-}
+    > a:not(:hover) {
+      color: var(--nve-sys-text-muted-color) !important;
+    }
 
-[nve-text~='link'] {
-  color: var(--nve-sys-text-link-color) !important;
-  text-decoration: underline !important;
-  line-height: inherit !important;
-  width: initial !important;
+    > a[aria-current='page'] {
+      color: var(--nve-sys-text-link-hover-color) !important;
+      font-weight: var(--nve-ref-font-weight-semibold) !important;
+    }
 
-  &[nve-text~='disabled'] {
-    color: var(--nve-sys-text-link-disabled-color) !important;
-  }
-
-  &:visited,
-  &[nve-text~='visited'] {
-    color: var(--nve-sys-text-link-visited-color) !important;
-  }
-
-  &:focus-visible {
-    outline: Highlight solid 2px !important;
-    outline: 5px auto -webkit-focus-ring-color !important;
-  }
-
-  &[nve-text~='no-visit'] {
-    color: var(--nve-sys-text-link-color) !important;
-  }
-
-  &[nve-text~='no-underline'] {
-    text-decoration: none !important;
-  }
-
-  &[nve-text~='xl'] {
-    font-size: var(--nve-ref-font-size-400) !important;
-  }
-
-  &[nve-text~='lg'] {
-    font-size: var(--nve-ref-font-size-300) !important;
-  }
-
-  &[nve-text~='sm'] {
-    font-size: var(--nve-ref-font-size-100) !important;
-  }
-
-  &[nve-text~='emphasis'] {
-    color: var(--nve-sys-text-link-emphasis-color) !important;
-  }
-
-  &:hover,
-  &[nve-text~='hover'] {
-    color: var(--nve-sys-text-link-hover-color) !important;
+    li {
+      margin-inline: var(--nve-ref-space-lg) 0 !important;
+    }
   }
 }
 
 /* color */
-[nve-text~='emphasis'] {
-  color: var(--nve-sys-text-emphasis-color) !important;
-}
-
-[nve-text~='muted'] {
-  color: var(--nve-sys-text-muted-color) !important;
-}
-
-[nve-text~='white'] {
-  color: var(--nve-sys-text-white-color) !important;
-}
-
-[nve-text~='black'] {
-  color: var(--nve-sys-text-black-color) !important;
-}
-
+[nve-text~='emphasis'],
+[nve-text~='muted'],
+[nve-text~='white'],
+[nve-text~='black'],
 [nve-text~='inherit'] {
-  color: inherit !important;
+  --_color: initial;
+  color: var(--_color) !important;
+
+  &[nve-text~='emphasis'] {
+    --_color: var(--nve-sys-text-emphasis-color);
+  }
+
+  &[nve-text~='muted'] {
+    --_color: var(--nve-sys-text-muted-color);
+  }
+
+  &[nve-text~='white'] {
+    --_color: var(--nve-sys-text-white-color);
+  }
+
+  &[nve-text~='black'] {
+    --_color: var(--nve-sys-text-black-color);
+  }
+
+  &[nve-text~='inherit'] {
+    --_color: inherit;
+  }
 }
 
 /* weights */
-[nve-text~='bold'] {
-  font-weight: var(--nve-ref-font-weight-bold) !important;
-}
-
-[nve-text~='semibold'] {
-  font-weight: var(--nve-ref-font-weight-semibold) !important;
-}
-
-[nve-text~='regular'] {
-  font-weight: var(--nve-ref-font-weight-regular) !important;
-}
-
-[nve-text~='medium'] {
-  font-weight: var(--nve-ref-font-weight-medium) !important;
-}
-
+[nve-text~='bold'],
+[nve-text~='semibold'],
+[nve-text~='regular'],
+[nve-text~='medium'],
 [nve-text~='light'] {
-  font-weight: var(--nve-ref-font-weight-light) !important;
+  --_font-weight: initial;
+  font-weight: var(--_font-weight) !important;
+
+  &[nve-text~='bold'] {
+    --_font-weight: var(--nve-ref-font-weight-bold);
+  }
+
+  &[nve-text~='semibold'] {
+    --_font-weight: var(--nve-ref-font-weight-semibold);
+  }
+
+  &[nve-text~='regular'] {
+    --_font-weight: var(--nve-ref-font-weight-regular);
+  }
+
+  &[nve-text~='medium'] {
+    --_font-weight: var(--nve-ref-font-weight-medium);
+  }
+
+  &[nve-text~='light'] {
+    --_font-weight: var(--nve-ref-font-weight-light);
+  }
 }
 
 /* transforms */
-[nve-text~='uppercase'] {
-  text-transform: uppercase !important;
-}
-
-[nve-text~='lowercase'] {
-  text-transform: lowercase !important;
-}
-
+[nve-text~='uppercase'],
+[nve-text~='lowercase'],
 [nve-text~='capitalize'] {
-  text-transform: capitalize !important;
+  --_text-transform: initial;
+  text-transform: var(--_text-transform) !important;
+
+  &[nve-text~='uppercase'] {
+    --_text-transform: uppercase;
+  }
+
+  &[nve-text~='lowercase'] {
+    --_text-transform: lowercase;
+  }
+
+  &[nve-text~='capitalize'] {
+    --_text-transform: capitalize;
+  }
 }
 
 /* line-heights */
-[nve-text~='tight'] {
-  line-height: var(--nve-ref-font-line-height-tight) !important;
-}
-
-[nve-text~='snug'] {
-  line-height: var(--nve-ref-font-line-height-snug) !important;
-}
-
-[nve-text~='moderate'] {
-  line-height: var(--nve-ref-font-line-height-moderate) !important;
-}
-
-[nve-text~='relaxed'] {
-  line-height: var(--nve-ref-font-line-height-relaxed) !important;
-}
-
+[nve-text~='tight'],
+[nve-text~='snug'],
+[nve-text~='moderate'],
+[nve-text~='relaxed'],
 [nve-text~='loose'] {
-  line-height: var(--nve-ref-font-line-height-loose) !important;
+  --_line-height: initial;
+  line-height: var(--_line-height) !important;
+
+  &[nve-text~='tight'] {
+    --_line-height: var(--nve-ref-font-line-height-tight);
+  }
+
+  &[nve-text~='snug'] {
+    --_line-height: var(--nve-ref-font-line-height-snug);
+  }
+
+  &[nve-text~='moderate'] {
+    --_line-height: var(--nve-ref-font-line-height-moderate);
+  }
+
+  &[nve-text~='relaxed'] {
+    --_line-height: var(--nve-ref-font-line-height-relaxed);
+  }
+
+  &[nve-text~='loose'] {
+    --_line-height: var(--nve-ref-font-line-height-loose);
+  }
 }
 
-[nve-text~='start'] {
-  text-align: start !important;
-}
-
-[nve-text~='center'] {
-  text-align: center !important;
-}
-
+/* text-align */
+[nve-text~='start'],
+[nve-text~='center'],
 [nve-text~='end'] {
-  text-align: end !important;
+  --_text-align: initial;
+  text-align: var(--_text-align) !important;
+
+  &[nve-text~='start'] {
+    --_text-align: start;
+  }
+
+  &[nve-text~='center'] {
+    --_text-align: center;
+  }
+
+  &[nve-text~='end'] {
+    --_text-align: end;
+  }
 }
 
 [nve-text~='truncate'] {
@@ -334,11 +386,12 @@ ul[nve-text~='nav'] ul li {
   padding: var(--nve-ref-size-50) var(--nve-ref-size-100) !important;
   color: var(--nve-sys-text-color) !important;
   font-family: monospace !important;
-  display: inline-block !important;
-}
+  line-height: inherit;
+  box-decoration-break: clone;
 
-[nve-text~='code'][nve-text~='flat'] {
-  background: transparent !important;
+  &[nve-text~='flat'] {
+    background: transparent !important;
+  }
 }
 
 [nve-text~='monospace'] {

--- a/projects/styles/src/typography.examples.ts
+++ b/projects/styles/src/typography.examples.ts
@@ -270,3 +270,17 @@ export const DescriptionList = {
 </dl>
   `
 }
+
+/**
+ * @summary Code and keyboard shortcut styles for displaying inline code snippets and keyboard shortcuts.
+ * @tags test-case
+ */
+export const Code = {
+  render: () => html`
+<div nve-layout="column gap:lg">
+  <kbd nve-text="code">CMD + C</kbd>
+  <code nve-text="code">console.log('Hello, world!');</code>
+  <p nve-text="body">The <code nve-text="code">console.log()</code> function is used to print messages to the console.</p>
+</div>
+  `
+}

--- a/projects/styles/src/typography.test.visual.ts
+++ b/projects/styles/src/typography.test.visual.ts
@@ -21,6 +21,45 @@ describe('typography visual', () => {
     expect(report.maxDiffPercentage).toBeLessThan(1);
   });
 
+  test('text line height should match visual baseline', async () => {
+    const report = await visualRunner.render(
+      'text-line-height',
+      /* html */ `
+      <div nve-layout="column gap:xl" style="width: 240px">
+        <p nve-text="display xl">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="display sm">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="heading xl">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="heading">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="body">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="label">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+      </div>
+    `
+    );
+
+    expect(report.maxDiffPercentage).toBeLessThan(1);
+  });
+
+  test('body text should support a 1.5 line-height override', async () => {
+    const report = await visualRunner.render(
+      'text-line-height-override',
+      /* html */ `
+      <style>
+        [data-line-height-override] [nve-text~='body'] {
+          line-height: 1.5 !important;
+        }
+      </style>
+      <div data-line-height-override nve-layout="column gap:xl" style="width: 240px">
+        <p nve-text="body xl tight">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="body lg tight">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="body tight">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+        <p nve-text="body sm tight">•︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎ •︎•︎•︎•︎ •︎•︎•︎•︎•︎•︎•︎•︎</p>
+      </div>
+    `
+    );
+
+    expect(report.maxDiffPercentage).toBeLessThan(1);
+  });
+
   // disabled due to flakeyness in CI
   // test('text size should match visual baseline', async () => {
   //   const report = await visualRunner.render(


### PR DESCRIPTION
- provide better line height defaults for nve-text utils
- refactor to improve consistency of behavior for nve-text utils

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refreshed the typography system to be driven by CSS custom properties across display, heading, body, label, link, list, and code variants.
  - Updated typography variant sizing and link-state styling, including current-page navigation font-weight behavior.
  - Consolidated related typography logic and adjusted code “flat” selector handling.

- **Tests**
  - Added visual regression tests for text line-height baselines and scoped body line-height overrides.
  - Loosened the compressed bundle-size limit check for `typography.css`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->