### PR TITLE
fix(styles): native text-box support

### DIFF
--- a/projects/styles/src/index.test.lighthouse.ts
+++ b/projects/styles/src/index.test.lighthouse.ts
@@ -23,7 +23,7 @@ describe('lighthouse report', () => {
   });
 
   test('typography.css should remain within compressed bundle limits', async () => {
-    expect(report.payload.css.requests['typography.css']!.kb).toBeLessThan(1.85);
+    expect(report.payload.css.requests['typography.css']!.kb).toBeLessThan(1.7);
   });
 
   test('view-transitions.css should remain within compressed bundle limits', async () => {
@@ -50,6 +50,6 @@ describe('lighthouse bundle report', () => {
   });
 
   test('bundles/index.css should remain within compressed bundle limits', async () => {
-    expect(report.payload.css.requests['index.css']!.kb).toBeLessThan(3.2);
+    expect(report.payload.css.requests['index.css']!.kb).toBeLessThan(3.1);
   });
 });

--- a/projects/styles/src/typography.css
+++ b/projects/styles/src/typography.css
@@ -37,36 +37,6 @@ body[nve-text],
   text-box: none !important;
 }
 
-@supports not (text-box: trim-both cap alphabetic) {
-  /* https://seek-oss.github.io/capsize/ (firefox, drop in v154) */
-  [nve-text] {
-    --_capsize-offset: -0.1818em;
-  }
-
-  :is([nve-text~='display'], [nve-text~='heading'], [nve-text~='body'], [nve-text~='label'])::before {
-    content: '';
-    margin-block-end: var(--_capsize-offset);
-    display: table;
-  }
-
-  :is([nve-text~='display'], [nve-text~='heading'], [nve-text~='body'], [nve-text~='label'])[nve-text]::after {
-    content: '';
-    margin-block-start: var(--_capsize-offset);
-    display: table;
-  }
-
-  [nve-text~='trim:none']::before,
-  [nve-text~='trim:none']::after {
-    content: none !important;
-  }
-
-  [nve-text~='truncate'] {
-    &::after {
-      --_capsize-offset: 0;
-    }
-  }
-}
-
 [nve-text~='display'] {
   --_font-size: var(--nve-ref-font-size-1000);
   --_line-height: var(--nve-ref-font-line-height-tight);


### PR DESCRIPTION
- use native css text-box support
- remove legacy fallback for firefox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typography styling by removing an outdated Firefox-specific fallback.
  * Reduced stylesheet size for faster loading.

* **Tests**
  * Updated stylesheet size checks to reflect the smaller compressed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->