### PR TITLE
feat(lint): add css rules

### DIFF
--- a/projects/core/.visual/progress-bar.dark.png
+++ b/projects/core/.visual/progress-bar.dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91a8546c309e11373c4525de94cb5f3f42a56a5b65b42645a60de15298d390a8
-size 1036
+oid sha256:49abb0b2fb259e8c57463a3d721d6f71df3e89ebb19d76f2e5c0689e47d9e331
+size 2513

--- a/projects/core/.visual/progress-bar.png
+++ b/projects/core/.visual/progress-bar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd171a152905992497d34b24a7b655c24e51717b345b9a5d34e1ab6d5afdc702
-size 1034
+oid sha256:20f8a47973a8e461a25fe059561b60b4d152b32e24126edc811a319fa76fdba0
+size 2477

--- a/projects/core/eslint.config.js
+++ b/projects/core/eslint.config.js
@@ -32,7 +32,8 @@ export default [
   // Disable no-missing-popover-trigger globally, only enable for examples
   {
     rules: {
-      '@nvidia-elements/lint/no-missing-popover-trigger': ['off']
+      '@nvidia-elements/lint/no-missing-popover-trigger': ['off'],
+      '@nvidia-elements/lint/no-custom-background-gradients': ['off'] // consumer APIs
     }
   },
   {

--- a/projects/core/src/progress-bar/progress-bar.css
+++ b/projects/core/src/progress-bar/progress-bar.css
@@ -77,7 +77,7 @@ progress.indeterminate {
   --indeterminate-gradient-reverse: linear-gradient(to left, var(--accent-color-faded) 10%, var(--accent-color));
   will-change: transform;
   background-image: var(--indeterminate-gradient);
-  animation: indeterminate-animation 2.4s infinite cubic-bezier(0.645, 0.045, 0.355, 1);
+  animation: indeterminate-animation calc(var(--nve-ref-animation-duration-400) * 3) infinite cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
 progress[value].indeterminate::-webkit-progress-value {

--- a/projects/lint/README.md
+++ b/projects/lint/README.md
@@ -65,6 +65,7 @@ export default [
 | Rule | Description | Language | Severity |
 | ---- | ----------- | -------- | -------- |
 | `@nvidia-elements/lint/no-complex-popovers` | Disallow excessive DOM complexity inside popover elements. | HTML | `error` |
+| `@nvidia-elements/lint/no-custom-background-gradients` | Disallow custom gradients in CSS backgrounds. | CSS | `error` |
 | `@nvidia-elements/lint/no-deprecated-attributes` | Disallow use of deprecated attributes in HTML. | HTML | `error` |
 | `@nvidia-elements/lint/no-deprecated-global-attribute-value` | Disallow use of deprecated attribute values for nve-* utility attributes. | HTML | `error` |
 | `@nvidia-elements/lint/no-deprecated-css-imports` | Disallow use of deprecated CSS import paths. | CSS | `error` |
@@ -75,6 +76,7 @@ export default [
 | `@nvidia-elements/lint/no-deprecated-popover-attributes` | Disallow use of deprecated popover attributes. | HTML | `error` |
 | `@nvidia-elements/lint/no-deprecated-slots` | Disallow use of deprecated slot APIs. | HTML | `error` |
 | `@nvidia-elements/lint/no-deprecated-tags` | Disallow use of deprecated elements in HTML. | HTML | `error` |
+| `@nvidia-elements/lint/no-display-override` | Disallow display overrides on Elements components. | CSS | `error` |
 | `@nvidia-elements/lint/no-excessive-primary-actions` | Limit primary actions to two per page. | HTML | `error` |
 | `@nvidia-elements/lint/no-invalid-event-listeners` | Disallow inline event handler attributes in HTML. | HTML | `error` |
 | `@nvidia-elements/lint/no-invalid-invoker-triggers` | Disallow use of invoker trigger attributes on non-button nve-* elements. | HTML | `error` |

--- a/projects/lint/src/eslint/configs/css.ts
+++ b/projects/lint/src/eslint/configs/css.ts
@@ -8,6 +8,8 @@ import noUnexpectedCssValue from '../rules/no-unexpected-css-value.js';
 import noUnknownCssVariable from '../rules/no-unknown-css-variable.js';
 import noDeprecatedCssVariable from '../rules/no-deprecated-css-variable.js';
 import noDeprecatedCssImports from '../rules/no-deprecated-css-imports.js';
+import noCustomBackgroundGradients from '../rules/no-custom-background-gradients.js';
+import noDisplayOverride from '../rules/no-display-override.js';
 
 const source = ['src/**/*.css'];
 const ignores = [
@@ -42,7 +44,9 @@ export const elementsCssConfig: Linter.Config = {
         'no-unexpected-css-value': noUnexpectedCssValue,
         'no-unknown-css-variable': noUnknownCssVariable,
         'no-deprecated-css-variable': noDeprecatedCssVariable,
-        'no-deprecated-css-imports': noDeprecatedCssImports
+        'no-deprecated-css-imports': noDeprecatedCssImports,
+        'no-custom-background-gradients': noCustomBackgroundGradients,
+        'no-display-override': noDisplayOverride
       }
     }
   },
@@ -51,6 +55,8 @@ export const elementsCssConfig: Linter.Config = {
     '@nvidia-elements/lint/no-unexpected-css-value': ['error'],
     '@nvidia-elements/lint/no-unknown-css-variable': ['error'],
     '@nvidia-elements/lint/no-deprecated-css-variable': ['error'],
-    '@nvidia-elements/lint/no-deprecated-css-imports': ['error']
+    '@nvidia-elements/lint/no-deprecated-css-imports': ['error'],
+    '@nvidia-elements/lint/no-display-override': ['error'],
+    '@nvidia-elements/lint/no-custom-background-gradients': ['error']
   }
 };

--- a/projects/lint/src/eslint/internals/css.test.ts
+++ b/projects/lint/src/eslint/internals/css.test.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { selectorTargetsNveElement, selectorsForRule } from './css.js';
+import type { CssRuleNode, CssSelectorChild, CssSelectorNode } from '../rule-types.js';
+
+function typeSelector(name: string): CssSelectorChild {
+  return { type: 'TypeSelector', name };
+}
+
+function selector(...children: CssSelectorChild[]): CssSelectorNode {
+  return { type: 'Selector', children };
+}
+
+function cssRule(prelude?: CssRuleNode['prelude']): CssRuleNode {
+  return prelude === undefined ? { type: 'Rule' } : { type: 'Rule', prelude };
+}
+
+describe('CSS selector helpers', () => {
+  it('should return selectors from a selector-list rule', () => {
+    const nveCard = selector(typeSelector('nve-card'));
+    const input = selector(typeSelector('input'));
+
+    expect(selectorsForRule(cssRule())).toEqual([]);
+    expect(selectorsForRule(cssRule({ type: 'AtRule' }))).toEqual([]);
+    expect(selectorsForRule(cssRule({ type: 'SelectorList' }))).toEqual([]);
+    expect(selectorsForRule(cssRule({ type: 'SelectorList', children: [nveCard, input] }))).toEqual([nveCard, input]);
+  });
+
+  it('should identify selectors that target Elements components', () => {
+    expect(selectorTargetsNveElement(selector(typeSelector('nve-card')), false)).toBe(true);
+    expect(
+      selectorTargetsNveElement(
+        selector(typeSelector('nve-card'), { type: 'Combinator', name: '>' }, typeSelector('input')),
+        false
+      )
+    ).toBe(false);
+    expect(selectorTargetsNveElement(selector({ type: 'NestingSelector' }), true)).toBe(true);
+    expect(selectorTargetsNveElement(selector(typeSelector('div')), false)).toBe(false);
+    expect(
+      selectorTargetsNveElement(
+        selector(typeSelector('nve-card'), { type: 'PseudoElementSelector', name: 'part' }),
+        false
+      )
+    ).toBe(false);
+  });
+});

--- a/projects/lint/src/eslint/internals/css.ts
+++ b/projects/lint/src/eslint/internals/css.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CssRuleNode, CssSelectorChild, CssSelectorNode } from '../rule-types.js';
+
+const IDENTITY_PSEUDO_CLASSES = new Set(['is', 'where']);
+
+function isNveTypeSelector(child: CssSelectorChild): boolean {
+  return child.type === 'TypeSelector' && child.name?.toLowerCase().startsWith('nve-') === true;
+}
+
+function isNestingSelector(child: CssSelectorChild): boolean {
+  return child.type === 'NestingSelector';
+}
+
+function selectorChildren(selector: CssSelectorNode): CssSelectorChild[] {
+  return selector.children ?? [];
+}
+
+function lastCompound(selector: CssSelectorNode): CssSelectorChild[] {
+  const children = selectorChildren(selector);
+  let start = 0;
+  for (let index = 0; index < children.length; index += 1) {
+    if (children[index]?.type === 'Combinator') start = index + 1;
+  }
+  return children.slice(start);
+}
+
+function pseudoClassTargetsNveElement(child: CssSelectorChild): boolean {
+  if (
+    child.type !== 'PseudoClassSelector' ||
+    child.name === undefined ||
+    !IDENTITY_PSEUDO_CLASSES.has(child.name.toLowerCase())
+  ) {
+    return false;
+  }
+
+  const selectorList = child.children?.find(argument => argument.type === 'SelectorList');
+  const selectors = selectorList?.children as CssSelectorNode[] | undefined;
+  return selectors?.some(selector => selectorTargetsNveElement(selector, false)) ?? false;
+}
+
+export function selectorsForRule(node: CssRuleNode): CssSelectorNode[] {
+  if (node.prelude?.type !== 'SelectorList') return [];
+  return (node.prelude.children ?? []).filter(selector => selector.type === 'Selector');
+}
+
+export function selectorTargetsNveElement(selector: CssSelectorNode, parentTargetsNve: boolean): boolean {
+  const compound = lastCompound(selector);
+  if (compound.some(child => child.type === 'PseudoElementSelector')) return false;
+  return (
+    compound.some(isNveTypeSelector) ||
+    compound.some(pseudoClassTargetsNveElement) ||
+    (parentTargetsNve && compound.some(isNestingSelector))
+  );
+}

--- a/projects/lint/src/eslint/rule-types.ts
+++ b/projects/lint/src/eslint/rule-types.ts
@@ -60,6 +60,44 @@ export interface CssAtRuleNode {
   [key: string]: unknown;
 }
 
+/** CSS qualified rule node from CSS parser */
+export interface CssRuleNode {
+  type: string;
+  prelude?: CssSelectorListNode;
+  loc?: { start: { line: number; column: number }; end: { line: number; column: number } };
+  range?: [number, number];
+  [key: string]: unknown;
+}
+
+/** CSS selector list node from CSS parser */
+interface CssSelectorListNode {
+  type: string;
+  children?: CssSelectorNode[];
+  loc?: { start: { line: number; column: number }; end: { line: number; column: number } };
+  range?: [number, number];
+  [key: string]: unknown;
+}
+
+/** CSS selector node from CSS parser */
+export interface CssSelectorNode {
+  type: string;
+  children?: CssSelectorChild[];
+  loc?: { start: { line: number; column: number }; end: { line: number; column: number } };
+  range?: [number, number];
+  [key: string]: unknown;
+}
+
+/** CSS selector child node from CSS parser */
+export interface CssSelectorChild {
+  type: string;
+  name?: string;
+  value?: string;
+  children?: CssSelectorChild[] | CssSelectorNode[] | null;
+  loc?: { start: { line: number; column: number }; end: { line: number; column: number } };
+  range?: [number, number];
+  [key: string]: unknown;
+}
+
 /** CSS value child node */
 export interface CssValueChild {
   type: string;

--- a/projects/lint/src/eslint/rules/no-custom-background-gradients.test.ts
+++ b/projects/lint/src/eslint/rules/no-custom-background-gradients.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import type { JSRuleDefinition } from 'eslint';
+import css from '@eslint/css';
+import noCustomBackgroundGradients from './no-custom-background-gradients.js';
+
+describe('noCustomBackgroundGradients', () => {
+  let tester: RuleTester;
+
+  beforeEach(() => {
+    tester = new RuleTester({
+      language: 'css/css',
+      languageOptions: { tolerant: true },
+      plugins: { css }
+    });
+  });
+
+  it('should define rule metadata', () => {
+    expect(noCustomBackgroundGradients.meta.docs.description).toBe('Disallow custom gradients in CSS backgrounds.');
+    expect(noCustomBackgroundGradients.meta.docs.recommended).toBe(false);
+  });
+
+  it('should disallow gradients in background declarations', () => {
+    tester.run('no-custom-background-gradients', noCustomBackgroundGradients as unknown as JSRuleDefinition, {
+      valid: [
+        '.surface { background: var(--nve-sys-background); }',
+        '.surface { background-image: url("linear-gradient(icon).svg"); }',
+        '.surface { --background: url("linear-gradient(icon).svg"); }',
+        '.surface { mask-image: linear-gradient(black, transparent); }'
+      ],
+      invalid: [
+        {
+          code: '.surface { background: linear-gradient(#000, #fff); }',
+          errors: [{ messageId: 'custom-background-gradient' }]
+        },
+        {
+          code: '.surface { background-image: radial-gradient(#000, #fff); }',
+          errors: [{ messageId: 'custom-background-gradient' }]
+        },
+        {
+          code: '.surface { background: repeating-conic-gradient(#000, #fff); }',
+          errors: [{ messageId: 'custom-background-gradient' }]
+        },
+        {
+          code: '.surface { --background: linear-gradient(#000, #fff); }',
+          errors: [{ messageId: 'custom-background-gradient' }]
+        }
+      ]
+    });
+  });
+});

--- a/projects/lint/src/eslint/rules/no-custom-background-gradients.ts
+++ b/projects/lint/src/eslint/rules/no-custom-background-gradients.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Rule } from 'eslint';
+import { CSSLanguage } from '@eslint/css';
+import type { CssDeclarationNode, CssValueChild } from '../rule-types.js';
+
+declare const __ELEMENTS_PAGES_BASE_URL__: string;
+
+const BACKGROUND_PROPERTIES = new Set(['background', 'background-image', '--background']);
+const GRADIENT_FUNCTIONS = new Set([
+  'conic-gradient',
+  'linear-gradient',
+  'radial-gradient',
+  'repeating-conic-gradient',
+  'repeating-linear-gradient',
+  'repeating-radial-gradient'
+]);
+const cssLanguage = new CSSLanguage();
+
+function isGradientFunctionChild(child: CssValueChild): boolean {
+  return child.type === 'Function' && GRADIENT_FUNCTIONS.has(child.name.toLowerCase());
+}
+
+function customBackgroundValueChildren(value: string): CssValueChild[] {
+  const parsed = cssLanguage.parse(
+    { body: `.value { background: ${value}; }`, path: 'custom-property.css' } as Parameters<CSSLanguage['parse']>[0],
+    { languageOptions: { tolerant: true } }
+  );
+  if (!parsed.ok) return [];
+
+  const rule = parsed.ast.children[0] as unknown as {
+    block?: { children?: Array<{ value?: { children?: CssValueChild[] } }> };
+  };
+  return rule?.block?.children?.[0]?.value?.children ?? [];
+}
+
+const rule = {
+  meta: {
+    type: 'problem' as const,
+    docs: {
+      description: 'Disallow custom gradients in CSS backgrounds.',
+      category: 'Best Practice',
+      recommended: false,
+      url: `${__ELEMENTS_PAGES_BASE_URL__}/docs/lint/`
+    },
+    schema: [],
+    messages: {
+      ['custom-background-gradient']:
+        'Unexpected custom gradient in a CSS background. Use Elements theme surfaces and tokens instead.'
+    }
+  },
+  create(context: Rule.RuleContext) {
+    return {
+      Declaration(node: CssDeclarationNode) {
+        if (!BACKGROUND_PROPERTIES.has(node.property)) return;
+        const children =
+          node.property === '--background'
+            ? customBackgroundValueChildren(context.sourceCode.getText(node.value as unknown as Rule.Node))
+            : node.value.children;
+        if (!children?.some(isGradientFunctionChild)) return;
+
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: 'custom-background-gradient'
+        });
+      }
+    };
+  }
+} as const;
+
+export default rule;

--- a/projects/lint/src/eslint/rules/no-display-override.test.ts
+++ b/projects/lint/src/eslint/rules/no-display-override.test.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import type { JSRuleDefinition } from 'eslint';
+import css from '@eslint/css';
+import noDisplayOverride from './no-display-override.js';
+
+describe('noDisplayOverride', () => {
+  let tester: RuleTester;
+
+  beforeEach(() => {
+    tester = new RuleTester({
+      language: 'css/css',
+      languageOptions: { tolerant: true },
+      plugins: { css }
+    });
+  });
+
+  it('should define rule metadata', () => {
+    expect(noDisplayOverride.meta.docs.description).toBe('Disallow display overrides on Elements components.');
+    expect(noDisplayOverride.meta.docs.recommended).toBe(true);
+  });
+
+  it('should disallow display overrides on Elements components', () => {
+    tester.run('no-display-override', noDisplayOverride as unknown as JSRuleDefinition, {
+      valid: [
+        '.layout { display: grid; }',
+        '.layout:has(nve-grid) { display: grid; }',
+        ':not(nve-card) { display: grid; }',
+        ':is(nve-card, .card) > input { display: grid; }',
+        'nve-card { display: none; }',
+        'nve-card::part(header) { display: flex; }',
+        'nve-card { & > input { display: block; } }'
+      ],
+      invalid: [
+        {
+          code: 'nve-card { display: flex; }',
+          errors: [{ messageId: 'display-override', data: { value: 'flex' } }]
+        },
+        {
+          code: '.layout > nve-grid { display: block; }',
+          errors: [{ messageId: 'display-override', data: { value: 'block' } }]
+        },
+        {
+          code: ':is(nve-card, nve-grid) { display: flex; }',
+          errors: [{ messageId: 'display-override', data: { value: 'flex' } }]
+        },
+        {
+          code: ':where(nve-card, .card) { display: grid; }',
+          errors: [{ messageId: 'display-override', data: { value: 'grid' } }]
+        },
+        {
+          code: 'nve-card { &:hover { display: grid; } }',
+          errors: [{ messageId: 'display-override', data: { value: 'grid' } }]
+        }
+      ]
+    });
+  });
+});

--- a/projects/lint/src/eslint/rules/no-display-override.ts
+++ b/projects/lint/src/eslint/rules/no-display-override.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Rule } from 'eslint';
+import { selectorTargetsNveElement, selectorsForRule } from '../internals/css.js';
+import type { CssDeclarationNode, CssRuleNode } from '../rule-types.js';
+
+declare const __ELEMENTS_PAGES_BASE_URL__: string;
+
+const rule = {
+  meta: {
+    type: 'problem' as const,
+    docs: {
+      description: 'Disallow display overrides on Elements components.',
+      category: 'Best Practice',
+      recommended: true,
+      url: `${__ELEMENTS_PAGES_BASE_URL__}/docs/lint/`
+    },
+    schema: [],
+    messages: {
+      ['display-override']:
+        'Unexpected "display: {{value}}" override on an nve-* element. Use the component API or a wrapper for layout.'
+    }
+  },
+  create(context: Rule.RuleContext) {
+    const ruleTargetStack: boolean[] = [];
+
+    return {
+      Rule(node: CssRuleNode) {
+        const parentTargetsNve = ruleTargetStack[ruleTargetStack.length - 1] ?? false;
+        const targetsNve = selectorsForRule(node).some(selector =>
+          selectorTargetsNveElement(selector, parentTargetsNve)
+        );
+        ruleTargetStack.push(targetsNve);
+      },
+      'Rule:exit'() {
+        ruleTargetStack.pop();
+      },
+      Declaration(node: CssDeclarationNode) {
+        if (node.property !== 'display' || !ruleTargetStack[ruleTargetStack.length - 1]) return;
+
+        const value = context.sourceCode
+          .getText(node.value as unknown as Rule.Node)
+          .trim()
+          .toLowerCase();
+        if (value === 'none') return;
+
+        context.report({
+          node: node as unknown as Rule.Node,
+          messageId: 'display-override',
+          data: { value }
+        });
+      }
+    };
+  }
+} as const;
+
+export default rule;

--- a/projects/site/src/_internal/canvas/canvas.css
+++ b/projects/site/src/_internal/canvas/canvas.css
@@ -23,6 +23,7 @@
 
 :host([layer='highlight']) {
   .resizer slot:not([name]) {
+    /* eslint-disable-next-line @nvidia-elements/lint/no-custom-background-gradients */
     background: linear-gradient(to right, #4e54c8, #8f94fb) !important;
   }
 }

--- a/projects/site/src/docs/lint/index.md
+++ b/projects/site/src/docs/lint/index.md
@@ -50,7 +50,7 @@ eslint -c ./eslint.config.js --color
 
 ## Severity
 
-You can adjust rules individually for lint severity. By default all rules use `error`.
+You can adjust rules individually for lint severity. The rules table lists the default severity for each rule.
 
 ```javascript
 import { elementsHtmlConfig, elementsCssConfig } from '@nvidia-elements/lint/eslint';
@@ -61,6 +61,7 @@ export default [
   {
     ...elementsCssConfig,
     rules: {
+      ...elementsCssConfig.rules,
       '@nvidia-elements/lint/no-unexpected-css-value': 'warn'
     }
   }
@@ -80,6 +81,12 @@ export default [
     <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-complex-popovers</code></nve-grid-cell>
     <nve-grid-cell>Disallow excessive DOM complexity inside popover elements.</nve-grid-cell>
     <nve-grid-cell>HTML</nve-grid-cell>
+    <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
+  </nve-grid-row>
+  <nve-grid-row>
+    <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-custom-background-gradients</code></nve-grid-cell>
+    <nve-grid-cell>Disallow custom gradients in CSS backgrounds.</nve-grid-cell>
+    <nve-grid-cell>CSS</nve-grid-cell>
     <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
   </nve-grid-row>
   <nve-grid-row>
@@ -140,6 +147,12 @@ export default [
     <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-deprecated-tags</code></nve-grid-cell>
     <nve-grid-cell>Disallow use of deprecated elements in HTML.</nve-grid-cell>
     <nve-grid-cell>HTML</nve-grid-cell>
+    <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
+  </nve-grid-row>
+  <nve-grid-row>
+    <nve-grid-cell><code nve-text="code">@nvidia-elements/lint/no-display-override</code></nve-grid-cell>
+    <nve-grid-cell>Disallow display overrides on Elements components.</nve-grid-cell>
+    <nve-grid-cell>CSS</nve-grid-cell>
     <nve-grid-cell><code nve-text="code">error</code></nve-grid-cell>
   </nve-grid-row>
   <nve-grid-row>


### PR DESCRIPTION
- Add `no-custom-background-gradients` rule
- Add `no-display-override` rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added CSS linting rules to flag custom background gradients and non-`none` display overrides on NVE elements.
  - Rules recognize nested CSS, selector lists, and common pseudo-classes.

- **Documentation**
  - Documented the new rules, default error severity, and configurable settings.
  - Updated lint configuration guidance and rule listings.

- **Bug Fixes**
  - Preserved the approved custom gradient used by the site resizer.
  - Updated indeterminate progress animation timing to use the standard design token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->