### PR TITLE
chore(ci): enable bundle tree shaking

### DIFF
--- a/projects/code/src/index.test.lighthouse.ts
+++ b/projects/code/src/index.test.lighthouse.ts
@@ -50,7 +50,7 @@ describe('lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.requests[Object.keys(report.payload.javascript.requests)[0]!]!.kb).toBeLessThan(36);
+    expect(report.payload.javascript.requests[Object.keys(report.payload.javascript.requests)[0]!]!.kb).toBeLessThan(17.5);
   });
 });
 
@@ -62,6 +62,6 @@ describe('lighthouse report', () => {
       </script>
     `);
 
-    expect(report.payload.javascript.kb).toBeLessThan(36);
+    expect(report.payload.javascript.kb).toBeLessThan(18.57);
   });
 });

--- a/projects/core/src/index.test.lighthouse.ts
+++ b/projects/core/src/index.test.lighthouse.ts
@@ -18,7 +18,7 @@ describe('lighthouse report', () => {
     expect(report.scores.performance).toBe(100);
     expect(report.scores.accessibility).toBe(100);
     expect(report.scores.bestPractices).toBe(100);
-    expect(report.payload.javascript.requests['index.js'].kb).toBeLessThan(136);
+    expect(report.payload.javascript.requests['index.js'].kb).toBeLessThan(106.14);
 
     // if sudden drop in size, check vite bundle config and bundle demo to ensure side effects are properly preserved
     expect(report.payload.javascript.requests['index.js'].kb).toBeGreaterThan(100);

--- a/projects/internals/vite/src/configs/build.bundle.js
+++ b/projects/internals/vite/src/configs/build.bundle.js
@@ -25,7 +25,7 @@ export const libraryBundleConfig = {
       }
     },
     rolldownOptions: {
-      treeshake: false,
+      treeshake: true,
       output: {
         minify: true,
         codeSplitting: false,

--- a/projects/monaco/src/index.test.lighthouse.ts
+++ b/projects/monaco/src/index.test.lighthouse.ts
@@ -12,7 +12,7 @@ describe('lighthouse report', () => {
       </script>
     `);
 
-    expect(report.payload.javascript.kb).toBeLessThan(1115);
-    expect(report.payload.javascript.requests['dist.js'].kb).toBeLessThan(1114);
+    expect(report.payload.javascript.kb).toBeLessThan(1114.15);
+    expect(report.payload.javascript.requests['dist.js'].kb).toBeLessThan(1112.81);
   });
 });

--- a/projects/site/src/_11ty/shortcodes/example.js
+++ b/projects/site/src/_11ty/shortcodes/example.js
@@ -123,11 +123,11 @@ function reloadScript(example, canvasId) {
 <script type="module">
   import examples from '${example.entrypoint}' with { type: 'json' };
   const rawTemplate = examples?.items?.find(s => s.id === '${example.id}')?.template ?? '';
-  // remove any import statements that may be in the raw example template as these are replaced by vite
   const container = document.querySelector('#${canvasId}_content:not(:has(iframe))');
   if (container) {
     // parse the template to extract script tags since innerHTML does not execute scripts
-    const template = rawTemplate.replace(/import\\s+(?:(?:\\{[^}]*\\}|\\w+)\\s+from\\s+)?['"][^'"]*['"];?/g, '');
+    ${rewriteDevImports.toString()}
+    const template = rewriteDevImports(rawTemplate);
     const parser = new DOMParser();
     const doc = parser.parseFromString('<body>' + template + '</body>', 'text/html');
     const scripts = doc.querySelectorAll('script');
@@ -141,6 +141,15 @@ function reloadScript(example, canvasId) {
     });
   }
 </script>`.replace(/\n\n/g, '\n');
+}
+
+export function rewriteDevImports(template) {
+  return template.replace(/<script\b(?=[^>]*\s+type\s*=\s*(['"])module\1)[^>]*>[\s\S]*?<\/script>/gi, script =>
+    script.replace(
+      /(\bfrom\s+|\bimport\s+)(['"])((?![./]|[a-zA-Z][a-zA-Z\d+.-]*:)[^'"]+)\2/g,
+      (_match, prefix, quote, specifier) => `${prefix}${quote}/@id/${specifier}${quote}`
+    )
+  );
 }
 
 function findExample(ref, exampleName) {

--- a/projects/site/src/_11ty/shortcodes/example.test.ts
+++ b/projects/site/src/_11ty/shortcodes/example.test.ts
@@ -45,4 +45,53 @@ describe('exampleShortcode', () => {
     expect(html).toContain('src="/examples/@internals/patterns/chat-pattern-chat-popover-chat/index.html"');
     expect(html).not.toContain('/docs/patterns/chat/examples/');
   });
+
+  it('should preserve imported example bindings when rewriting development module imports', async () => {
+    const { rewriteDevImports } = await importShortcode();
+    const template = `<script type="module">
+      import { Badge, Button } from '@nvidia-elements/core';
+      import 'lit';
+      import './local.js';
+      const constructors = [Badge, Button];
+    </script>`;
+
+    expect(rewriteDevImports(template)).toBe(`<script type="module">
+      import { Badge, Button } from '/@id/@nvidia-elements/core';
+      import '/@id/lit';
+      import './local.js';
+      const constructors = [Badge, Button];
+    </script>`);
+  });
+
+  it('should preserve absolute URL imports when rewriting development module imports', async () => {
+    const { rewriteDevImports } = await importShortcode();
+    const template = `<script type="module">
+      import 'http://localhost:3000/component.js';
+      import { register } from 'https://cdn.example.com/component.js';
+      import '@nvidia-elements/core';
+    </script>`;
+
+    expect(rewriteDevImports(template)).toBe(`<script type="module">
+      import 'http://localhost:3000/component.js';
+      import { register } from 'https://cdn.example.com/component.js';
+      import '/@id/@nvidia-elements/core';
+    </script>`);
+  });
+
+  it('should only rewrite imports in module script blocks', async () => {
+    const { rewriteDevImports } = await importShortcode();
+    const template = `<nve-codeblock language="typescript">
+      import '@nvidia-elements/core/chat-message/define.js';
+    </nve-codeblock>
+    <script type="module">
+      import '@nvidia-elements/core/chat-message/define.js';
+    </script>`;
+
+    expect(rewriteDevImports(template)).toBe(`<nve-codeblock language="typescript">
+      import '@nvidia-elements/core/chat-message/define.js';
+    </nve-codeblock>
+    <script type="module">
+      import '/@id/@nvidia-elements/core/chat-message/define.js';
+    </script>`);
+  });
 });

--- a/projects/site/src/_11ty/shortcodes/index.js
+++ b/projects/site/src/_11ty/shortcodes/index.js
@@ -21,7 +21,7 @@ export async function installShortcode(tag) {
   import '${element?.manifest?.metadata?.entrypoint}/define.js';
 </script>
 
-${examples.find(s => s.name === 'Default' && s.element === tag)?.template}
+${examples.find(s => s.name === 'Default' && s.element === tag)?.template ?? ''}
 \`\`\`
 
 <div nve-layout="column gap:xs" role="region" aria-label="AI Agent API access via CLI or MCP">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development reload handling for examples using package and side-effect imports.
  * Preserved relative and absolute imports during example reloads.
  * Prevented missing example templates from displaying incorrect placeholder content.

* **Performance**
  * Enabled tree-shaking to reduce generated library bundle sizes.
  * Tightened Lighthouse bundle-size limits to help maintain smaller payloads.

* **Tests**
  * Added coverage for import rewriting and bundle-size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->