### PR TITLE
chore(internals): add performance eslint rules for typescript

### DIFF
--- a/projects/internals/eslint/README.md
+++ b/projects/internals/eslint/README.md
@@ -29,7 +29,15 @@ import { browserTypescriptConfig, libraryConfig, litConfig, jsonConfig } from '@
 export default [...browserTypescriptConfig, ...libraryConfig, ...litConfig, ...jsonConfig];
 ```
 
-Plugin namespaces (`local-typescript`, `local-html`, `local-css`, `local-json`) register the custom rules inside those configs. Projects do not opt in per rule.
+Performance rules use a separate config. Spread `performanceConfig` to enable every performance rule for production TypeScript:
+
+```js
+import { browserTypescriptConfig, performanceConfig } from '@internals/eslint';
+
+export default [...browserTypescriptConfig, ...performanceConfig];
+```
+
+Plugin namespaces (`local-typescript`, `local-performance`, `local-html`, `local-css`, `local-json`) register the custom rules inside those configs.
 
 ## Authoring a new rule
 
@@ -110,3 +118,18 @@ Applied to `package.json` files.
 
 - **`no-missing-bundle-registration`**. A component that ships a `define.ts` must also appear in `src/bundle.ts` so the CDN bundle registers it.
 - **`no-missing-bundle-test`**. Every component registered by `src/bundle.ts` must also appear in the Lighthouse direct-import benchmark. The required `lighthouseTestFile` option names the project's combined Lighthouse test file.
+
+### Performance rules
+
+The `performanceConfig` enables these rules as errors for production TypeScript files.
+
+- **`prefer-direct-typed-array-iteration`**. Avoids `Array.from(typedArray)` copies before operations such as `some`, `find`, and `forEach` that do not transform the array.
+- **`require-animation-frame-cleanup`**. Requires a class that stores an animation frame handle to cancel that handle.
+- **`require-observer-disconnect`**. Requires observers stored on class fields to call `disconnect()`. The rule recognizes standard observer constructors and the repository's observer factory names.
+- **`no-inline-gpu-upload-allocation`**. Flags typed arrays and other buffer sources constructed directly in WebGPU `writeBuffer` and `writeTexture` calls.
+- **`no-hot-path-collection-allocation`**. Flags collection-producing array operations, collection constructors, `Array.from`, and array spread inside explicit or recognized renderer hot paths.
+- **`no-hot-path-buffer-allocation`**. Flags typed arrays, `ArrayBuffer`, and `DataView` construction inside explicit or recognized renderer hot paths.
+- **`no-gpu-upload-in-loop`**. Flags direct WebGPU queue uploads inside loops and collection callbacks so callers batch work before crossing the browser boundary.
+- **`require-gpu-resource-cleanup`**. Requires owning classes to destroy buffers, textures, and query sets retained on class fields.
+
+Add `@hotPath` to a function or method to opt it into hot-path allocation checks. The rules also treat methods beginning with `draw`, `prepare`, or `render` on classes whose names end in `Renderer` as hot paths.

--- a/projects/internals/eslint/src/configs/performance.js
+++ b/projects/internals/eslint/src/configs/performance.js
@@ -1,0 +1,58 @@
+import noGpuUploadInLoop from '../local/no-gpu-upload-in-loop.js';
+import noHotPathBufferAllocation from '../local/no-hot-path-buffer-allocation.js';
+import noHotPathCollectionAllocation from '../local/no-hot-path-collection-allocation.js';
+import noInlineGpuUploadAllocation from '../local/no-inline-gpu-upload-allocation.js';
+import preferDirectTypedArrayIteration from '../local/prefer-direct-typed-array-iteration.js';
+import requireAnimationFrameCleanup from '../local/require-animation-frame-cleanup.js';
+import requireGpuResourceCleanup from '../local/require-gpu-resource-cleanup.js';
+import requireObserverDisconnect from '../local/require-observer-disconnect.js';
+
+const source = ['src/**/*.ts', 'src/**/*.tsx'];
+const ignores = [
+  '**/*.examples.ts',
+  '**/*.test*.ts',
+  '**/*.test*.tsx',
+  'build/',
+  'coverage/',
+  'dist/',
+  'node_modules/'
+];
+
+/**
+ * Enables performance rules for production TypeScript. Consumers may override
+ * individual severities in a later flat-config entry after spreading this config.
+ *
+ * @type {import('eslint').Linter.Config[]}
+ */
+export const performanceConfig = [
+  {
+    plugins: {
+      'local-performance': {
+        rules: {
+          'no-gpu-upload-in-loop': noGpuUploadInLoop,
+          'no-hot-path-buffer-allocation': noHotPathBufferAllocation,
+          'no-hot-path-collection-allocation': noHotPathCollectionAllocation,
+          'no-inline-gpu-upload-allocation': noInlineGpuUploadAllocation,
+          'prefer-direct-typed-array-iteration': preferDirectTypedArrayIteration,
+          'require-animation-frame-cleanup': requireAnimationFrameCleanup,
+          'require-gpu-resource-cleanup': requireGpuResourceCleanup,
+          'require-observer-disconnect': requireObserverDisconnect
+        }
+      }
+    }
+  },
+  {
+    files: source,
+    ignores,
+    rules: {
+      'local-performance/no-gpu-upload-in-loop': 'error',
+      'local-performance/no-hot-path-buffer-allocation': 'error',
+      'local-performance/no-hot-path-collection-allocation': 'error',
+      'local-performance/no-inline-gpu-upload-allocation': 'error',
+      'local-performance/prefer-direct-typed-array-iteration': 'error',
+      'local-performance/require-animation-frame-cleanup': 'error',
+      'local-performance/require-gpu-resource-cleanup': 'error',
+      'local-performance/require-observer-disconnect': 'error'
+    }
+  }
+];

--- a/projects/internals/eslint/src/configs/performance.test.js
+++ b/projects/internals/eslint/src/configs/performance.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { performanceConfig } from './performance.js';
+
+test('enables performance rules for production TypeScript', () => {
+  assert.equal(performanceConfig.length, 2);
+  const [pluginConfig, ruleConfig] = performanceConfig;
+  assert.deepEqual(ruleConfig.files, ['src/**/*.ts', 'src/**/*.tsx']);
+  assert.equal(ruleConfig.ignores.includes('**/*.test*.ts'), true);
+  assert.deepEqual(Object.keys(pluginConfig.plugins['local-performance'].rules).sort(), [
+    'no-gpu-upload-in-loop',
+    'no-hot-path-buffer-allocation',
+    'no-hot-path-collection-allocation',
+    'no-inline-gpu-upload-allocation',
+    'prefer-direct-typed-array-iteration',
+    'require-animation-frame-cleanup',
+    'require-gpu-resource-cleanup',
+    'require-observer-disconnect'
+  ]);
+  assert.equal(
+    Object.values(ruleConfig.rules).every(severity => severity === 'error'),
+    true
+  );
+});

--- a/projects/internals/eslint/src/configs/typescript.js
+++ b/projects/internals/eslint/src/configs/typescript.js
@@ -164,6 +164,7 @@ const config = {
         tags: { name: true },
         aria: { name: true },
         experimental: { name: true },
+        hotPath: { name: false },
         alpha: { name: true },
         beta: { name: true },
         stable: { name: true },

--- a/projects/internals/eslint/src/index.js
+++ b/projects/internals/eslint/src/index.js
@@ -4,5 +4,6 @@ export { jsonConfig } from './configs/json.js';
 export { libraryConfig } from './configs/library.js';
 export { appConfig } from './configs/app.js';
 export { litConfig } from './configs/lit.js';
+export { performanceConfig } from './configs/performance.js';
 export { browserTypescriptConfig, nodeTypescriptConfig } from './configs/typescript.js';
 export { cssConfig } from './configs/css.js';

--- a/projects/internals/eslint/src/local/no-gpu-upload-in-loop.js
+++ b/projects/internals/eslint/src/local/no-gpu-upload-in-loop.js
@@ -1,0 +1,90 @@
+const ITERATION_METHODS = new Set([
+  'every',
+  'filter',
+  'find',
+  'findIndex',
+  'flatMap',
+  'forEach',
+  'map',
+  'reduce',
+  'reduceRight',
+  'some'
+]);
+const LOOP_NODES = new Set(['DoWhileStatement', 'ForInStatement', 'ForOfStatement', 'ForStatement', 'WhileStatement']);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    name: 'no-gpu-upload-in-loop',
+    docs: {
+      description: 'Flags direct WebGPU queue uploads repeated by loops or collection callbacks.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'repeated-upload':
+        '`{{method}}` runs inside repeated iteration. Batch uploads or merge dirty ranges before crossing the WebGPU boundary.'
+    }
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const method = getUploadMethod(node.callee);
+        if (method && isRepeated(node)) {
+          context.report({ node, messageId: 'repeated-upload', data: { method } });
+        }
+      }
+    };
+  }
+};
+
+function getUploadMethod(callee) {
+  if (callee.type !== 'MemberExpression' || !isGpuQueue(callee.object)) return null;
+  const name = callee.computed
+    ? callee.property.type === 'Literal' && typeof callee.property.value === 'string'
+      ? callee.property.value
+      : undefined
+    : callee.property.type === 'Identifier'
+      ? callee.property.name
+      : undefined;
+  return name === 'writeBuffer' || name === 'writeTexture' ? name : null;
+}
+
+function isGpuQueue(node) {
+  if (node.type === 'Identifier') return /queue$/iu.test(node.name);
+  if (node.type !== 'MemberExpression') return false;
+  if (!node.computed && node.property.type === 'Identifier') return /queue$/iu.test(node.property.name);
+  return node.property.type === 'Literal' && typeof node.property.value === 'string'
+    ? /queue$/iu.test(node.property.value)
+    : false;
+}
+
+function isRepeated(node) {
+  let current = node.parent;
+  while (current) {
+    if (LOOP_NODES.has(current.type)) return true;
+    if (isFunction(current)) return isIterationCallback(current);
+    current = current.parent;
+  }
+  return false;
+}
+
+function isFunction(node) {
+  return (
+    node.type === 'ArrowFunctionExpression' || node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression'
+  );
+}
+
+function isIterationCallback(node) {
+  const call = node.parent;
+  if (call?.type !== 'CallExpression' || !call.arguments.includes(node)) return false;
+  const callee = call.callee;
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    ITERATION_METHODS.has(callee.property.name)
+  );
+}

--- a/projects/internals/eslint/src/local/no-gpu-upload-in-loop.test.js
+++ b/projects/internals/eslint/src/local/no-gpu-upload-in-loop.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import noGpuUploadInLoop from './no-gpu-upload-in-loop.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: { parser: tseslint.parser, parserOptions: { ecmaVersion: 'latest', sourceType: 'module' } }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(noGpuUploadInLoop.meta.type, 'suggestion');
+  assert.equal(noGpuUploadInLoop.meta.name, 'no-gpu-upload-in-loop');
+  assert.ok(noGpuUploadInLoop.meta.messages['repeated-upload']);
+});
+
+test('valid: accepts single uploads and separately declared callbacks', () => {
+  tester.run('no-gpu-upload-in-loop', noGpuUploadInLoop, {
+    valid: [
+      { code: `queue.writeBuffer(buffer, 0, bytes);` },
+      { code: `for (const value of values) writer.writeBuffer(value);` },
+      {
+        code: `
+          const upload = bytes => queue.writeBuffer(buffer, 0, bytes);
+          for (const bytes of batches) schedule(upload, bytes);
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports queue uploads in loops and collection callbacks', () => {
+  tester.run('no-gpu-upload-in-loop', noGpuUploadInLoop, {
+    valid: [],
+    invalid: [
+      {
+        code: `for (const range of ranges) queue.writeBuffer(buffer, range.offset, range.bytes);`,
+        errors: [{ messageId: 'repeated-upload', data: { method: 'writeBuffer' } }]
+      },
+      {
+        code: `images.forEach(image => queue.writeTexture(destination, image, layout, size));`,
+        errors: [{ messageId: 'repeated-upload', data: { method: 'writeTexture' } }]
+      },
+      {
+        code: `while (pending()) queue['writeBuffer'](buffer, 0, next());`,
+        errors: [{ messageId: 'repeated-upload', data: { method: 'writeBuffer' } }]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/no-hot-path-buffer-allocation.js
+++ b/projects/internals/eslint/src/local/no-hot-path-buffer-allocation.js
@@ -1,0 +1,76 @@
+import { isHotPath, walk } from './utils.js';
+
+const BUFFER_CONSTRUCTORS = new Set([
+  'ArrayBuffer',
+  'BigInt64Array',
+  'BigUint64Array',
+  'DataView',
+  'Float32Array',
+  'Float64Array',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'SharedArrayBuffer',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array'
+]);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    name: 'no-hot-path-buffer-allocation',
+    docs: {
+      description: 'Flags buffer and view construction in annotated and renderer hot paths.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'buffer-constructor':
+        '`new {{kind}}` allocates storage or a view inside a hot path. Reuse owned scratch storage or move initialization outside the repeated path.'
+    }
+  },
+  create(context) {
+    return {
+      FunctionDeclaration(node) {
+        if (isHotPath(context, node)) inspectHotPath(context, node.body);
+      },
+      MethodDefinition(node) {
+        if (isHotPath(context, node)) inspectHotPath(context, node.value.body);
+      },
+      PropertyDefinition(node) {
+        if (isFunction(node.value) && isHotPath(context, node)) inspectHotPath(context, node.value.body);
+      },
+      VariableDeclaration(node) {
+        if (!isHotPath(context, node)) return;
+        for (const declaration of node.declarations) {
+          if (isFunction(declaration.init)) inspectHotPath(context, declaration.init.body);
+        }
+      }
+    };
+  }
+};
+
+function isFunction(node) {
+  return (
+    node?.type === 'ArrowFunctionExpression' ||
+    node?.type === 'FunctionDeclaration' ||
+    node?.type === 'FunctionExpression'
+  );
+}
+
+function inspectHotPath(context, body) {
+  walk(body, node => {
+    if (isFunction(node)) return false;
+    if (
+      node.type === 'NewExpression' &&
+      node.callee.type === 'Identifier' &&
+      BUFFER_CONSTRUCTORS.has(node.callee.name)
+    ) {
+      context.report({ node, messageId: 'buffer-constructor', data: { kind: node.callee.name } });
+    }
+  });
+}

--- a/projects/internals/eslint/src/local/no-hot-path-buffer-allocation.test.js
+++ b/projects/internals/eslint/src/local/no-hot-path-buffer-allocation.test.js
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import noHotPathBufferAllocation from './no-hot-path-buffer-allocation.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: { parser: tseslint.parser, parserOptions: { ecmaVersion: 'latest', sourceType: 'module' } }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(noHotPathBufferAllocation.meta.type, 'suggestion');
+  assert.equal(noHotPathBufferAllocation.meta.name, 'no-hot-path-buffer-allocation');
+  assert.ok(noHotPathBufferAllocation.meta.messages['buffer-constructor']);
+});
+
+test('valid: accepts reusable buffers and allocations outside hot paths', () => {
+  tester.run('no-hot-path-buffer-allocation', noHotPathBufferAllocation, {
+    valid: [
+      { code: `function initialize() { return new Float32Array(40); }` },
+      {
+        code: `
+          class GeometryRenderer {
+            #scratch = new Float32Array(40);
+            draw() {
+              this.#scratch.fill(0);
+            }
+          }
+        `
+      },
+      {
+        code: `
+          /** @hotPath */
+          function tick() {
+            function initialize() {
+              return new Float32Array(40);
+            }
+            return () => new Uint8Array(8);
+          }
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports buffer construction in annotated and renderer hot paths', () => {
+  tester.run('no-hot-path-buffer-allocation', noHotPathBufferAllocation, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          /** @hotPath */
+          function tick(bytes) {
+            const view = new DataView(bytes.buffer);
+            return new Uint8Array(view.byteLength);
+          }
+        `,
+        errors: [
+          { messageId: 'buffer-constructor', data: { kind: 'DataView' } },
+          { messageId: 'buffer-constructor', data: { kind: 'Uint8Array' } }
+        ]
+      },
+      {
+        code: `
+          class MeshRenderer {
+            prepare() {
+              return new Float32Array(16);
+            }
+          }
+        `,
+        errors: [{ messageId: 'buffer-constructor', data: { kind: 'Float32Array' } }]
+      },
+      {
+        code: `class LabelRenderer { draw = () => new Uint32Array(1); }`,
+        errors: [{ messageId: 'buffer-constructor', data: { kind: 'Uint32Array' } }]
+      },
+      {
+        code: `
+          /** @hotPath */
+          export default function tick() {
+            return new Int8Array(8);
+          }
+        `,
+        errors: [{ messageId: 'buffer-constructor', data: { kind: 'Int8Array' } }]
+      },
+      {
+        code: `
+          /** @hotPath */
+          function tick() {
+            class NestedRenderer {
+              draw() {
+                return new Float64Array(8);
+              }
+            }
+            return NestedRenderer;
+          }
+        `,
+        errors: [{ messageId: 'buffer-constructor', data: { kind: 'Float64Array' } }]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/no-hot-path-collection-allocation.js
+++ b/projects/internals/eslint/src/local/no-hot-path-collection-allocation.js
@@ -1,0 +1,137 @@
+import { isHotPath, walk } from './utils.js';
+
+const ALLOCATING_METHODS = new Set([
+  'concat',
+  'filter',
+  'flat',
+  'flatMap',
+  'map',
+  'slice',
+  'toReversed',
+  'toSorted',
+  'toSpliced',
+  'with'
+]);
+const ALLOCATING_CONSTRUCTORS = new Set(['Array', 'Map', 'Set']);
+const COLLECTION_TYPE_NAMES = new Set([
+  'Array',
+  'BigInt64Array',
+  'BigUint64Array',
+  'Float32Array',
+  'Float64Array',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'ReadonlyArray',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array'
+]);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    name: 'no-hot-path-collection-allocation',
+    docs: {
+      description: 'Flags collection-producing operations in explicit and recognized renderer hot paths.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'allocating-method':
+        '`{{method}}` creates a collection inside a hot path. Iterate directly or reuse caller-owned scratch storage.',
+      'array-copy': '`Array.from` creates a collection inside a hot path. Iterate the source directly when possible.',
+      'array-spread': 'Array spread creates a collection inside a hot path. Iterate the source directly when possible.',
+      'collection-constructor':
+        '`new {{kind}}` creates a collection inside a hot path. Reuse owned storage or move initialization outside the repeated path.'
+    }
+  },
+  create(context) {
+    const services = context.sourceCode.parserServices;
+    const checker = services?.program?.getTypeChecker();
+    const nodeMap = services?.esTreeNodeToTSNodeMap;
+
+    return {
+      FunctionDeclaration(node) {
+        if (isHotPath(context, node)) inspectHotPath(context, node.body, checker, nodeMap);
+      },
+      MethodDefinition(node) {
+        if (isHotPath(context, node)) inspectHotPath(context, node.value.body, checker, nodeMap);
+      },
+      PropertyDefinition(node) {
+        if (isFunction(node.value) && isHotPath(context, node))
+          inspectHotPath(context, node.value.body, checker, nodeMap);
+      },
+      VariableDeclaration(node) {
+        if (!isHotPath(context, node)) return;
+        for (const declaration of node.declarations) {
+          if (isFunction(declaration.init)) inspectHotPath(context, declaration.init.body, checker, nodeMap);
+        }
+      }
+    };
+  }
+};
+
+function isFunction(node) {
+  return (
+    node?.type === 'ArrowFunctionExpression' ||
+    node?.type === 'FunctionDeclaration' ||
+    node?.type === 'FunctionExpression'
+  );
+}
+
+function inspectHotPath(context, body, checker, nodeMap) {
+  walk(body, node => {
+    if (isFunction(node)) return false;
+    if (
+      node.type === 'NewExpression' &&
+      node.callee.type === 'Identifier' &&
+      ALLOCATING_CONSTRUCTORS.has(node.callee.name)
+    ) {
+      context.report({ node, messageId: 'collection-constructor', data: { kind: node.callee.name } });
+      return;
+    }
+    if (node.type === 'ArrayExpression' && node.elements.some(element => element?.type === 'SpreadElement')) {
+      context.report({ node, messageId: 'array-spread' });
+      return;
+    }
+    if (node.type !== 'CallExpression') return;
+    if (isArrayFrom(node.callee)) {
+      context.report({ node, messageId: 'array-copy' });
+      return;
+    }
+    const method = getAllocatingMethod(node.callee, checker, nodeMap);
+    if (method) context.report({ node, messageId: 'allocating-method', data: { method } });
+  });
+}
+
+function isArrayFrom(callee) {
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'Array' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'from'
+  );
+}
+
+function getAllocatingMethod(callee, checker, nodeMap) {
+  if (callee.type !== 'MemberExpression' || callee.computed || callee.property.type !== 'Identifier') return null;
+  const receiver = nodeMap?.get(callee.object);
+  if (!checker || !receiver || !isCollectionType(checker, checker.getTypeAtLocation(receiver))) return null;
+  return ALLOCATING_METHODS.has(callee.property.name) ? callee.property.name : null;
+}
+
+function isCollectionType(checker, type) {
+  if (type.isUnion()) return type.types.every(member => isCollectionType(checker, member));
+  if (type.isIntersection()) return type.types.some(member => isCollectionType(checker, member));
+  if (checker.isArrayType(type) || checker.isTupleType(type)) return true;
+  const name = type.getSymbol()?.getName();
+  if (name !== undefined && COLLECTION_TYPE_NAMES.has(name)) return true;
+  const constraint = checker.getBaseConstraintOfType(type);
+  return constraint !== undefined && constraint !== type && isCollectionType(checker, constraint);
+}

--- a/projects/internals/eslint/src/local/no-hot-path-collection-allocation.test.js
+++ b/projects/internals/eslint/src/local/no-hot-path-collection-allocation.test.js
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import noHotPathCollectionAllocation from './no-hot-path-collection-allocation.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        projectService: { allowDefaultProject: ['*.ts'] },
+        tsconfigRootDir: import.meta.dirname
+      }
+    }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(noHotPathCollectionAllocation.meta.type, 'suggestion');
+  assert.equal(noHotPathCollectionAllocation.meta.name, 'no-hot-path-collection-allocation');
+  assert.ok(noHotPathCollectionAllocation.meta.messages['allocating-method']);
+  assert.ok(noHotPathCollectionAllocation.meta.messages['collection-constructor']);
+});
+
+test('valid: ignores unannotated functions and allocation-free hot paths', () => {
+  tester.run('no-hot-path-collection-allocation', noHotPathCollectionAllocation, {
+    valid: [
+      { filename: 'performance-rule.ts', code: `function collect(items: number[]) { return items.filter(Boolean); }` },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          /** @hotPath */
+          function draw(items: number[]) {
+            for (const item of items) consume(item);
+          }
+        `
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          class SceneRenderer {
+            draw(items: number[]) {
+              const cache = new WeakMap();
+              for (const item of items) consume(item);
+              return cache;
+            }
+          }
+        `
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          /** @hotPath */
+          function draw(items: number[]) {
+            function collect() {
+              return new Set(items);
+            }
+            return () => items.filter(Boolean);
+          }
+        `
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          class PointRenderer {
+            map(point: number) {
+              return point;
+            }
+            draw(point: number) {
+              return this.map(point);
+            }
+          }
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports collection allocations in annotated functions and methods', () => {
+  tester.run('no-hot-path-collection-allocation', noHotPathCollectionAllocation, {
+    valid: [],
+    invalid: [
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          /** @hotPath */
+          function draw(items: number[]) {
+            const visible = items.filter(Boolean);
+            const copy = Array.from(items);
+            return [...visible, ...copy];
+          }
+        `,
+        errors: [
+          { messageId: 'allocating-method', data: { method: 'filter' } },
+          { messageId: 'array-copy' },
+          { messageId: 'array-spread' }
+        ]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          class Renderer {
+            draw(items: Array<{ id: number }>) {
+              const active = new Set(items);
+              return items.map(item => item.id + active.size);
+            }
+          }
+        `,
+        errors: [
+          { messageId: 'collection-constructor', data: { kind: 'Set' } },
+          { messageId: 'allocating-method', data: { method: 'map' } }
+        ]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          /** @hotPath */
+          export const draw = (items: number[]) => items.slice();
+        `,
+        errors: [{ messageId: 'allocating-method', data: { method: 'slice' } }]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          class Renderer {
+            /** @hotPath */
+            draw = (items: number[]) => items.toSorted();
+          }
+        `,
+        errors: [{ messageId: 'allocating-method', data: { method: 'toSorted' } }]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          /** @hotPath */
+          function draw() {
+            class NestedRenderer {
+              prepare(items: number[]) {
+                return Array.from(items);
+              }
+            }
+            return NestedRenderer;
+          }
+        `,
+        errors: [{ messageId: 'array-copy' }]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/no-inline-gpu-upload-allocation.js
+++ b/projects/internals/eslint/src/local/no-inline-gpu-upload-allocation.js
@@ -1,0 +1,69 @@
+const BUFFER_SOURCE_CONSTRUCTORS = new Set([
+  'ArrayBuffer',
+  'BigInt64Array',
+  'BigUint64Array',
+  'DataView',
+  'Float32Array',
+  'Float64Array',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array'
+]);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    name: 'no-inline-gpu-upload-allocation',
+    docs: {
+      description: 'Flags inline BufferSource allocation in WebGPU queue uploads.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'inline-upload-allocation':
+        '`{{method}}` allocates a `{{kind}}` inline. Reuse a scratch BufferSource in repeated upload paths to avoid per-frame garbage.'
+    }
+  },
+  create(context) {
+    const services = context.sourceCode.parserServices;
+    const checker = services?.program?.getTypeChecker();
+    const nodeMap = services?.esTreeNodeToTSNodeMap;
+
+    return {
+      CallExpression(node) {
+        const method = getUploadMethod(node.callee, checker, nodeMap);
+        if (!method) return;
+        const source = node.arguments[method === 'writeBuffer' ? 2 : 1];
+        if (!source || source.type !== 'NewExpression' || source.callee.type !== 'Identifier') return;
+        if (!BUFFER_SOURCE_CONSTRUCTORS.has(source.callee.name)) return;
+        context.report({
+          node: source,
+          messageId: 'inline-upload-allocation',
+          data: { kind: source.callee.name, method }
+        });
+      }
+    };
+  }
+};
+
+function getUploadMethod(callee, checker, nodeMap) {
+  if (callee.type !== 'MemberExpression' || callee.computed || callee.property.type !== 'Identifier') return null;
+  const receiver = nodeMap?.get(callee.object);
+  if (!checker || !receiver || !isGpuQueueType(checker.getTypeAtLocation(receiver))) return null;
+  return callee.property.name === 'writeBuffer' || callee.property.name === 'writeTexture'
+    ? callee.property.name
+    : null;
+}
+
+function isGpuQueueType(type) {
+  if (type.isUnion()) return type.types.every(isGpuQueueType);
+  if (type.isIntersection()) return type.types.some(isGpuQueueType);
+  if (type.getSymbol()?.getName() === 'GPUQueue') return true;
+  return type.getBaseTypes()?.some(isGpuQueueType) === true;
+}

--- a/projects/internals/eslint/src/local/no-inline-gpu-upload-allocation.test.js
+++ b/projects/internals/eslint/src/local/no-inline-gpu-upload-allocation.test.js
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import noInlineGpuUploadAllocation from './no-inline-gpu-upload-allocation.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        projectService: { allowDefaultProject: ['*.ts'] },
+        tsconfigRootDir: import.meta.dirname
+      }
+    }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(noInlineGpuUploadAllocation.meta.type, 'suggestion');
+  assert.equal(noInlineGpuUploadAllocation.meta.name, 'no-inline-gpu-upload-allocation');
+  assert.ok(noInlineGpuUploadAllocation.meta.messages['inline-upload-allocation']);
+});
+
+test('valid: accepts reusable upload sources and unrelated constructors', () => {
+  tester.run('no-inline-gpu-upload-allocation', noInlineGpuUploadAllocation, {
+    valid: [
+      {
+        filename: 'performance-rule.ts',
+        code: `declare const queue: GPUQueue; queue.writeBuffer(buffer, 0, scratch);`
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `declare const queue: GPUQueue; queue.writeTexture(destination, pixels, layout, size);`
+      },
+      { filename: 'performance-rule.ts', code: `consume(new Uint32Array([1]));` },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          class Writer {
+            writeBuffer(buffer: unknown, offset: number, source: Uint32Array) {
+              consume(buffer, offset, source);
+            }
+            upload() {
+              this.writeBuffer(buffer, 0, new Uint32Array([1]));
+            }
+          }
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports inline BufferSource allocations in GPU uploads', () => {
+  tester.run('no-inline-gpu-upload-allocation', noInlineGpuUploadAllocation, {
+    valid: [],
+    invalid: [
+      {
+        filename: 'performance-rule.ts',
+        code: `declare const queue: GPUQueue; queue.writeBuffer(buffer, 0, new Uint32Array([pickId]));`,
+        errors: [
+          {
+            messageId: 'inline-upload-allocation',
+            data: { kind: 'Uint32Array', method: 'writeBuffer' }
+          }
+        ]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `declare const queue: GPUQueue; queue.writeTexture(destination, new Uint8Array([255]), layout, size);`,
+        errors: [
+          {
+            messageId: 'inline-upload-allocation',
+            data: { kind: 'Uint8Array', method: 'writeTexture' }
+          }
+        ]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/prefer-direct-typed-array-iteration.js
+++ b/projects/internals/eslint/src/local/prefer-direct-typed-array-iteration.js
@@ -1,0 +1,82 @@
+const TERMINAL_METHODS = new Set(['every', 'find', 'findIndex', 'forEach', 'reduce', 'reduceRight', 'some']);
+const TYPED_ARRAY_NAMES = new Set([
+  'BigInt64Array',
+  'BigUint64Array',
+  'Float32Array',
+  'Float64Array',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array'
+]);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    name: 'prefer-direct-typed-array-iteration',
+    docs: {
+      description: 'Avoids copying typed arrays with Array.from before operations that do not transform the array.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'unnecessary-copy':
+        '`Array.from` copies this typed array before `{{method}}`. Call `{{method}}` on the typed array directly to avoid the allocation.'
+    }
+  },
+  create(context) {
+    const services = context.sourceCode.parserServices;
+    const checker = services?.program?.getTypeChecker();
+    const nodeMap = services?.esTreeNodeToTSNodeMap;
+    if (!checker || !nodeMap) return {};
+
+    return {
+      CallExpression(node) {
+        const match = matchCopiedTerminalCall(node);
+        if (!match || !isTypedArray(checker, nodeMap.get(match.source))) return;
+        context.report({
+          node: match.copy,
+          messageId: 'unnecessary-copy',
+          data: { method: match.method }
+        });
+      }
+    };
+  }
+};
+
+function matchCopiedTerminalCall(node) {
+  const callee = node.callee;
+  if (callee.type !== 'MemberExpression' || callee.computed || callee.property.type !== 'Identifier') return null;
+  if (!TERMINAL_METHODS.has(callee.property.name)) return null;
+  const copy = callee.object;
+  if (copy.type !== 'CallExpression' || copy.arguments.length !== 1) return null;
+  const from = copy.callee;
+  if (
+    from.type !== 'MemberExpression' ||
+    from.computed ||
+    from.object.type !== 'Identifier' ||
+    from.object.name !== 'Array' ||
+    from.property.type !== 'Identifier' ||
+    from.property.name !== 'from'
+  ) {
+    return null;
+  }
+  const source = copy.arguments[0];
+  return source.type === 'SpreadElement' ? null : { copy, method: callee.property.name, source };
+}
+
+function isTypedArray(checker, node) {
+  const type = checker.getTypeAtLocation(node);
+  if (type.isUnion()) return type.types.every(member => isTypedArrayType(member));
+  return isTypedArrayType(type);
+}
+
+function isTypedArrayType(type) {
+  const name = type.getSymbol()?.getName() ?? type.aliasSymbol?.getName();
+  return name !== undefined && TYPED_ARRAY_NAMES.has(name);
+}

--- a/projects/internals/eslint/src/local/prefer-direct-typed-array-iteration.test.js
+++ b/projects/internals/eslint/src/local/prefer-direct-typed-array-iteration.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import preferDirectTypedArrayIteration from './prefer-direct-typed-array-iteration.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        projectService: { allowDefaultProject: ['*.ts'] },
+        tsconfigRootDir: import.meta.dirname
+      }
+    }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(preferDirectTypedArrayIteration.meta.type, 'suggestion');
+  assert.equal(preferDirectTypedArrayIteration.meta.name, 'prefer-direct-typed-array-iteration');
+  assert.equal(preferDirectTypedArrayIteration.meta.fixable, undefined);
+});
+
+test('valid: preserves DOM collection conversion and direct typed-array iteration', () => {
+  tester.run('prefer-direct-typed-array-iteration', preferDirectTypedArrayIteration, {
+    valid: [
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          declare const options: HTMLOptionsCollection;
+          Array.from(options).some(option => option.disabled);
+        `
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          const values = new Float32Array(4);
+          values.some(value => value < 0);
+          Array.from(values, value => value * 2).some(value => value < 0);
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports unnecessary typed-array copies without unsafe fixes', () => {
+  tester.run('prefer-direct-typed-array-iteration', preferDirectTypedArrayIteration, {
+    valid: [],
+    invalid: [
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          const colors = new Float32Array(4);
+          Array.from(colors).some(value => value < 0);
+        `,
+        output: null,
+        errors: [{ messageId: 'unnecessary-copy', data: { method: 'some' } }]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          const values = new Float32Array([1, 2]);
+          Array.from(values).some((value, index) => {
+            if (index === 0) values[1] = 0;
+            return value === 2;
+          });
+        `,
+        output: null,
+        errors: [{ messageId: 'unnecessary-copy', data: { method: 'some' } }]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          const indices = new Uint32Array(4);
+          Array.from(indices).forEach(index => void index);
+        `,
+        output: null,
+        errors: [{ messageId: 'unnecessary-copy', data: { method: 'forEach' } }]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          type Positions = Float32Array;
+          declare const positions: Positions;
+          Array.from(positions).some(position => position > 0);
+        `,
+        output: null,
+        errors: [{ messageId: 'unnecessary-copy', data: { method: 'some' } }]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          declare const condition: boolean;
+          const first = new Float32Array(4);
+          const second = new Float32Array(4);
+          Array.from(condition ? first : second).some(value => value < 0);
+        `,
+        output: null,
+        errors: [{ messageId: 'unnecessary-copy', data: { method: 'some' } }]
+      },
+      {
+        filename: 'performance-rule.ts',
+        code: `
+          const values = new Float32Array(4);
+          Object.defineProperty(values, Symbol.iterator, {
+            value: function* () {
+              yield 1;
+            }
+          });
+          Array.from(values).some(value => value < 0);
+        `,
+        output: null,
+        errors: [{ messageId: 'unnecessary-copy', data: { method: 'some' } }]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/require-animation-frame-cleanup.js
+++ b/projects/internals/eslint/src/local/require-animation-frame-cleanup.js
@@ -1,0 +1,71 @@
+import {
+  crossesInstanceThisContextBoundary,
+  findEnclosingClass,
+  isInstanceThisContextBoundary,
+  propertyDefinitionAsThisMember,
+  thisMemberText,
+  walk
+} from './utils.js';
+
+const REQUEST_NAME = 'requestAnimationFrame';
+const CANCEL_NAME = 'cancelAnimationFrame';
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    name: 'require-animation-frame-cleanup',
+    docs: {
+      description: 'Requires animation frame handles stored on a class to be canceled.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'missing-frame-cleanup':
+        '`requestAnimationFrame` stores its handle on `{{target}}`, but the class never calls `cancelAnimationFrame({{target}})`. Cancel pending frame work when the owner disconnects or disposes.'
+    }
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (getMemberCallName(node.callee) !== REQUEST_NAME) return;
+        const target = getStoredMemberText(node.parent, node, context);
+        if (crossesInstanceThisContextBoundary(node)) return;
+        const classNode = findEnclosingClass(node);
+        if (!classNode || !target || classHasCancellation(classNode, target, context)) return;
+        context.report({ node, messageId: 'missing-frame-cleanup', data: { target } });
+      }
+    };
+  }
+};
+
+function classHasCancellation(classNode, target, context) {
+  let found = false;
+  walk(classNode.body, node => {
+    if (isInstanceThisContextBoundary(node)) return false;
+    if (found || node.type !== 'CallExpression' || getMemberCallName(node.callee) !== CANCEL_NAME) return;
+    const argument = node.arguments[0];
+    if (argument && argument.type !== 'SpreadElement' && thisMemberText(argument, context) === target) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function getMemberCallName(callee) {
+  if (callee.type === 'Identifier') return callee.name;
+  if (callee.type !== 'MemberExpression' || callee.computed || callee.property.type !== 'Identifier') return null;
+  return callee.property.name;
+}
+
+function getStoredMemberText(parent, callNode, context) {
+  if (!parent) return null;
+  if (parent.type === 'AssignmentExpression' && parent.right === callNode) {
+    return thisMemberText(parent.left, context);
+  }
+  if (parent.type === 'PropertyDefinition' && parent.value === callNode) {
+    return propertyDefinitionAsThisMember(parent, context);
+  }
+  return null;
+}

--- a/projects/internals/eslint/src/local/require-animation-frame-cleanup.test.js
+++ b/projects/internals/eslint/src/local/require-animation-frame-cleanup.test.js
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import requireAnimationFrameCleanup from './require-animation-frame-cleanup.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: { parser: tseslint.parser, parserOptions: { ecmaVersion: 'latest', sourceType: 'module' } }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(requireAnimationFrameCleanup.meta.type, 'problem');
+  assert.equal(requireAnimationFrameCleanup.meta.name, 'require-animation-frame-cleanup');
+  assert.ok(requireAnimationFrameCleanup.meta.messages['missing-frame-cleanup']);
+});
+
+test('valid: stored animation frames are canceled and one-shots may be unstored', () => {
+  tester.run('require-animation-frame-cleanup', requireAnimationFrameCleanup, {
+    valid: [
+      {
+        code: `
+          class Scene {
+            schedule() {
+              this.#frame = scenePlatform.requestAnimationFrame(() => this.draw());
+            }
+            disconnect() {
+              scenePlatform.cancelAnimationFrame(this.#frame);
+            }
+          }
+        `
+      },
+      {
+        code: `requestAnimationFrame(() => draw());`
+      },
+      {
+        code: `
+          class Scene {
+            [frameKey] = requestAnimationFrame(() => this.draw());
+            disconnect() {
+              cancelAnimationFrame(this [frameKey]);
+            }
+          }
+        `
+      },
+      {
+        code: `
+          class Scene {
+            static schedule() {
+              this.frame = requestAnimationFrame(() => draw());
+            }
+            static {
+              this.frame = requestAnimationFrame(() => draw());
+            }
+            schedule() {
+              function nested() {
+                this.frame = requestAnimationFrame(() => draw());
+              }
+              return nested;
+            }
+          }
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports stored animation frames without cancellation', () => {
+  tester.run('require-animation-frame-cleanup', requireAnimationFrameCleanup, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          class Scene {
+            schedule() {
+              this.#frame = requestAnimationFrame(() => this.draw());
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-frame-cleanup', data: { target: 'this.#frame' } }]
+      },
+      {
+        code: `
+          class Scene {
+            #frame = globalThis.requestAnimationFrame(() => this.draw());
+          }
+        `,
+        errors: [{ messageId: 'missing-frame-cleanup', data: { target: 'this.#frame' } }]
+      },
+      {
+        code: `
+          class Scene {
+            #frame = requestAnimationFrame(() => this.draw());
+            method() {
+              class Nested {
+                #frame;
+                disconnect() {
+                  cancelAnimationFrame(this.#frame);
+                }
+              }
+              return Nested;
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-frame-cleanup', data: { target: 'this.#frame' } }]
+      },
+      {
+        code: `
+          class Scene {
+            frame = requestAnimationFrame(() => this.draw());
+            disconnect() {
+              function cancel() {
+                cancelAnimationFrame(this.frame);
+              }
+              return cancel;
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-frame-cleanup', data: { target: 'this.frame' } }]
+      },
+      {
+        code: `
+          class Scene {
+            frame = requestAnimationFrame(() => this.draw());
+            static {
+              cancelAnimationFrame(this.frame);
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-frame-cleanup', data: { target: 'this.frame' } }]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/require-gpu-resource-cleanup.js
+++ b/projects/internals/eslint/src/local/require-gpu-resource-cleanup.js
@@ -1,0 +1,87 @@
+import {
+  crossesInstanceThisContextBoundary,
+  findEnclosingClass,
+  isInstanceThisContextBoundary,
+  propertyDefinitionAsThisMember,
+  thisMemberText,
+  walk
+} from './utils.js';
+
+const GPU_RESOURCE_FACTORIES = new Set(['createBuffer', 'createQuerySet', 'createTexture']);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    name: 'require-gpu-resource-cleanup',
+    docs: {
+      description: 'Requires GPU buffers, textures, and query sets retained on class fields to be destroyed.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'missing-gpu-cleanup':
+        'The GPU resource stored on `{{target}}` is never destroyed. Call `{{target}}.destroy()` when its owner disconnects, disposes, or replaces it.'
+    }
+  },
+  create(context) {
+    return {
+      AssignmentExpression(node) {
+        checkStoredResource(context, node.right, thisMemberText(node.left, context));
+      },
+      PropertyDefinition(node) {
+        checkStoredResource(context, node.value, propertyDefinitionAsThisMember(node, context));
+      }
+    };
+  }
+};
+
+function checkStoredResource(context, value, target) {
+  if (!value || !target || !isGpuResourceCreation(value)) return;
+  if (crossesInstanceThisContextBoundary(value)) return;
+  const classNode = findEnclosingClass(value);
+  if (!classNode || classHasDestroy(classNode, target, context)) return;
+  context.report({ node: value, messageId: 'missing-gpu-cleanup', data: { target } });
+}
+
+function isGpuResourceCreation(node) {
+  if (node.type !== 'CallExpression') return false;
+  const callee = node.callee;
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    GPU_RESOURCE_FACTORIES.has(callee.property.name) &&
+    isGpuDevice(callee.object)
+  );
+}
+
+function isGpuDevice(node) {
+  if (node.type === 'Identifier') return /(?:device|gpu)$/iu.test(node.name);
+  if (node.type !== 'MemberExpression') return false;
+  if (!node.computed && (node.property.type === 'Identifier' || node.property.type === 'PrivateIdentifier')) {
+    return /(?:device|gpu)$/iu.test(node.property.name);
+  }
+  return node.property.type === 'Literal' && typeof node.property.value === 'string'
+    ? /(?:device|gpu)$/iu.test(node.property.value)
+    : false;
+}
+
+function classHasDestroy(classNode, target, context) {
+  let found = false;
+  walk(classNode.body, node => {
+    if (isInstanceThisContextBoundary(node)) return false;
+    if (found || node.type !== 'CallExpression') return;
+    const callee = node.callee;
+    if (
+      callee.type === 'MemberExpression' &&
+      callee.property.type === 'Identifier' &&
+      callee.property.name === 'destroy' &&
+      thisMemberText(callee.object, context) === target
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}

--- a/projects/internals/eslint/src/local/require-gpu-resource-cleanup.test.js
+++ b/projects/internals/eslint/src/local/require-gpu-resource-cleanup.test.js
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import requireGpuResourceCleanup from './require-gpu-resource-cleanup.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: { parser: tseslint.parser, parserOptions: { ecmaVersion: 'latest', sourceType: 'module' } }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(requireGpuResourceCleanup.meta.type, 'problem');
+  assert.equal(requireGpuResourceCleanup.meta.name, 'require-gpu-resource-cleanup');
+  assert.ok(requireGpuResourceCleanup.meta.messages['missing-gpu-cleanup']);
+});
+
+test('valid: accepts destroyed fields, local ownership transfer, and nondestroyable GPU objects', () => {
+  tester.run('require-gpu-resource-cleanup', requireGpuResourceCleanup, {
+    valid: [
+      {
+        code: `
+          class Targets {
+            initialize(device) {
+              this.#texture = device.createTexture({});
+            }
+            disconnect() {
+              this.#texture?.destroy?.();
+            }
+          }
+        `
+      },
+      { code: `function create(device) { return device.createBuffer({}); }` },
+      { code: `class PoolOwner { initialize(pool) { this.#buffer = pool.createBuffer({}); } }` },
+      {
+        code: `
+          class Renderer {
+            initialize(device) {
+              this.#pipeline = device.createRenderPipeline({});
+              this.#sampler = device.createSampler({});
+            }
+          }
+        `
+      },
+      {
+        code: `
+          class Renderer {
+            static initialize(device) {
+              this.buffer = device.createBuffer({});
+            }
+            static {
+              this.buffer = this.device.createBuffer({});
+            }
+            initialize(device) {
+              function nested() {
+                this.buffer = device.createBuffer({});
+              }
+              return nested;
+            }
+          }
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports retained destroyable GPU resources without cleanup', () => {
+  tester.run('require-gpu-resource-cleanup', requireGpuResourceCleanup, {
+    valid: [],
+    invalid: [
+      {
+        code: `class Renderer { initialize(device) { this.#buffer = device.createBuffer({}); } }`,
+        errors: [{ messageId: 'missing-gpu-cleanup', data: { target: 'this.#buffer' } }]
+      },
+      {
+        code: `class Renderer { #texture = this.device.createTexture({}); }`,
+        errors: [{ messageId: 'missing-gpu-cleanup', data: { target: 'this.#texture' } }]
+      },
+      {
+        code: `class Renderer { initialize(device) { this.queries = device.createQuerySet({}); } }`,
+        errors: [{ messageId: 'missing-gpu-cleanup', data: { target: 'this.queries' } }]
+      },
+      {
+        code: `
+          class Renderer {
+            #buffer = this.device.createBuffer({});
+            method() {
+              return class Nested {
+                #buffer;
+                disconnect() {
+                  this.#buffer.destroy();
+                }
+              };
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-gpu-cleanup', data: { target: 'this.#buffer' } }]
+      },
+      {
+        code: `
+          class Renderer {
+            buffer = this.device.createBuffer({});
+            disconnect() {
+              function cleanup() {
+                this.buffer.destroy();
+              }
+              return cleanup;
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-gpu-cleanup', data: { target: 'this.buffer' } }]
+      },
+      {
+        code: `
+          class Renderer {
+            buffer = this.device.createBuffer({});
+            static {
+              this.buffer.destroy();
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-gpu-cleanup', data: { target: 'this.buffer' } }]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/require-observer-disconnect.js
+++ b/projects/internals/eslint/src/local/require-observer-disconnect.js
@@ -1,0 +1,85 @@
+import {
+  crossesInstanceThisContextBoundary,
+  findEnclosingClass,
+  isInstanceThisContextBoundary,
+  propertyDefinitionAsThisMember,
+  thisMemberText,
+  walk
+} from './utils.js';
+
+const OBSERVER_NAMES = new Set(['IntersectionObserver', 'MutationObserver', 'PerformanceObserver', 'ResizeObserver']);
+const OBSERVER_FACTORIES = new Set([
+  'createIntersectionObserver',
+  'createMutationObserver',
+  'createPerformanceObserver',
+  'createResizeObserver'
+]);
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    name: 'require-observer-disconnect',
+    docs: {
+      description: 'Requires observer instances stored on class fields to be disconnected.',
+      category: 'Performance',
+      recommended: false
+    },
+    schema: [],
+    messages: {
+      'missing-observer-disconnect':
+        'The observer stored on `{{target}}` is never disconnected. Call `{{target}}.disconnect()` when the owner disconnects or disposes.'
+    }
+  },
+  create(context) {
+    return {
+      AssignmentExpression(node) {
+        checkStoredObserver(context, node.right, thisMemberText(node.left, context));
+      },
+      PropertyDefinition(node) {
+        checkStoredObserver(context, node.value, propertyDefinitionAsThisMember(node, context));
+      }
+    };
+  }
+};
+
+function checkStoredObserver(context, value, target) {
+  if (!value || !target || !isObserverCreation(value)) return;
+  if (crossesInstanceThisContextBoundary(value)) return;
+  const classNode = findEnclosingClass(value);
+  if (!classNode || classHasDisconnect(classNode, target, context)) return;
+  context.report({ node: value, messageId: 'missing-observer-disconnect', data: { target } });
+}
+
+function isObserverCreation(node) {
+  if (node.type === 'NewExpression') {
+    return node.callee.type === 'Identifier' && OBSERVER_NAMES.has(node.callee.name);
+  }
+  if (node.type !== 'CallExpression') return false;
+  const callee = node.callee;
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    OBSERVER_FACTORIES.has(callee.property.name)
+  );
+}
+
+function classHasDisconnect(classNode, target, context) {
+  let found = false;
+  walk(classNode.body, node => {
+    if (isInstanceThisContextBoundary(node)) return false;
+    if (found || node.type !== 'CallExpression') return;
+    const callee = node.callee;
+    if (
+      callee.type !== 'MemberExpression' ||
+      callee.computed ||
+      callee.property.type !== 'Identifier' ||
+      callee.property.name !== 'disconnect'
+    ) {
+      return;
+    }
+    if (thisMemberText(callee.object, context) === target) found = true;
+  });
+  return found;
+}

--- a/projects/internals/eslint/src/local/require-observer-disconnect.test.js
+++ b/projects/internals/eslint/src/local/require-observer-disconnect.test.js
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { beforeEach, test } from 'node:test';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import requireObserverDisconnect from './require-observer-disconnect.js';
+
+let tester;
+
+beforeEach(() => {
+  tester = new RuleTester({
+    languageOptions: { parser: tseslint.parser, parserOptions: { ecmaVersion: 'latest', sourceType: 'module' } }
+  });
+});
+
+test('defines rule metadata', () => {
+  assert.equal(requireObserverDisconnect.meta.type, 'problem');
+  assert.equal(requireObserverDisconnect.meta.name, 'require-observer-disconnect');
+  assert.ok(requireObserverDisconnect.meta.messages['missing-observer-disconnect']);
+});
+
+test('valid: class observers and configured platform factories are disconnected', () => {
+  tester.run('require-observer-disconnect', requireObserverDisconnect, {
+    valid: [
+      {
+        code: `
+          class Element {
+            #observer = new ResizeObserver(() => {});
+            disconnectedCallback() {
+              this.#observer.disconnect();
+            }
+          }
+        `
+      },
+      {
+        code: `
+          class Element {
+            connect() {
+              this.observer ??= platform.createMutationObserver(() => {});
+            }
+            disconnect() {
+              this.observer?.disconnect();
+            }
+          }
+        `
+      },
+      {
+        code: `
+          class Element {
+            static connect() {
+              this.observer = new ResizeObserver(() => {});
+            }
+            static {
+              this.observer = new ResizeObserver(() => {});
+            }
+            connect() {
+              function nested() {
+                this.observer = new ResizeObserver(() => {});
+              }
+              return nested;
+            }
+          }
+        `
+      }
+    ],
+    invalid: []
+  });
+});
+
+test('invalid: reports retained observers without disconnect', () => {
+  tester.run('require-observer-disconnect', requireObserverDisconnect, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          class Element {
+            #observer = new PerformanceObserver(() => {});
+          }
+        `,
+        errors: [{ messageId: 'missing-observer-disconnect', data: { target: 'this.#observer' } }]
+      },
+      {
+        code: `
+          class Element {
+            connect() {
+              this.#observer = platform.createResizeObserver(() => {});
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-observer-disconnect', data: { target: 'this.#observer' } }]
+      },
+      {
+        code: `
+          class Element {
+            #observer = new ResizeObserver(() => {});
+            method() {
+              class Nested {
+                #observer;
+                disconnect() {
+                  this.#observer.disconnect();
+                }
+              }
+              return Nested;
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-observer-disconnect', data: { target: 'this.#observer' } }]
+      },
+      {
+        code: `
+          class Element {
+            observer = new ResizeObserver(() => {});
+            disconnect() {
+              function cleanup() {
+                this.observer.disconnect();
+              }
+              return cleanup;
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-observer-disconnect', data: { target: 'this.observer' } }]
+      },
+      {
+        code: `
+          class Element {
+            observer = new ResizeObserver(() => {});
+            static {
+              this.observer.disconnect();
+            }
+          }
+        `,
+        errors: [{ messageId: 'missing-observer-disconnect', data: { target: 'this.observer' } }]
+      }
+    ]
+  });
+});

--- a/projects/internals/eslint/src/local/utils.js
+++ b/projects/internals/eslint/src/local/utils.js
@@ -3,6 +3,8 @@ import { dirname, join } from 'node:path';
 
 export const DEFAULT_IMPORT_PREFIX = '@nvidia-elements/core';
 
+const HOT_RENDERER_METHOD = /^(?:draw|prepare|render)(?:$|[A-Z])/u;
+
 export function getPackageName(startDirectory) {
   let directory = startDirectory;
 
@@ -37,7 +39,9 @@ export function walk(node, visit) {
   if (!node || typeof node !== 'object') {
     return;
   }
-  visit(node);
+  if (visit(node) === false) {
+    return;
+  }
   for (const key of Object.keys(node)) {
     if (key === 'parent') {
       continue;
@@ -57,6 +61,39 @@ export function normalize(text) {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+export function thisMemberText(node, context) {
+  if (node.type !== 'MemberExpression' || node.object.type !== 'ThisExpression') return null;
+  if (node.computed) return `this[${normalize(context.sourceCode.getText(node.property))}]`;
+  return normalize(context.sourceCode.getText(node));
+}
+
+export function propertyDefinitionAsThisMember(node, context) {
+  if (node.static) return null;
+  if (node.computed) return `this[${normalize(context.sourceCode.getText(node.key))}]`;
+  if (node.key.type === 'PrivateIdentifier') return `this.#${node.key.name}`;
+  if (node.key.type === 'Identifier') return `this.${node.key.name}`;
+  return `this[${normalize(context.sourceCode.getText(node.key))}]`;
+}
+
+export function isInstanceThisContextBoundary(node) {
+  if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression' || node.type === 'StaticBlock') return true;
+  if ((node.type === 'MethodDefinition' || node.type === 'PropertyDefinition') && node.static) return true;
+  return (
+    (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') &&
+    node.parent?.type !== 'MethodDefinition'
+  );
+}
+
+export function crossesInstanceThisContextBoundary(node) {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'ClassDeclaration' || current.type === 'ClassExpression') return false;
+    if (isInstanceThisContextBoundary(current)) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
 export function findEnclosingClass(node) {
   let current = node.parent;
   while (current) {
@@ -66,4 +103,30 @@ export function findEnclosingClass(node) {
     current = current.parent;
   }
   return null;
+}
+
+export function isHotPath(context, node) {
+  return hasHotPathComment(context, node) || isRendererHotPath(node);
+}
+
+function hasHotPathComment(context, node) {
+  let candidate = node;
+  while (candidate) {
+    if (context.sourceCode.getCommentsBefore(candidate).some(comment => /@hotPath\b/u.test(comment.value))) return true;
+    candidate =
+      candidate.parent?.type === 'ExportNamedDeclaration' || candidate.parent?.type === 'ExportDefaultDeclaration'
+        ? candidate.parent
+        : null;
+  }
+  return false;
+}
+
+function isRendererHotPath(node) {
+  if (node.type !== 'MethodDefinition' && node.type !== 'PropertyDefinition') return false;
+  const classNode = node.parent?.parent;
+  const className =
+    classNode?.type === 'ClassDeclaration' || classNode?.type === 'ClassExpression' ? classNode.id?.name : undefined;
+  const methodName =
+    node.key.type === 'Identifier' || node.key.type === 'PrivateIdentifier' ? node.key.name : undefined;
+  return className?.endsWith('Renderer') === true && methodName !== undefined && HOT_RENDERER_METHOD.test(methodName);
 }


### PR DESCRIPTION
- Introduced `performanceConfig` to enable performance-related ESLint rules for production TypeScript.
- Added rules: `no-gpu-upload-in-loop`, `no-hot-path-buffer-allocation`, `no-hot-path-collection-allocation`, `no-inline-gpu-upload-allocation`, `prefer-direct-typed-array-iteration`, `require-animation-frame-cleanup`, `require-gpu-resource-cleanup`, and `require-observer-disconnect`.
- Updated README to document the new performance rules and their usage.
- Added tests for the new rules to ensure correct functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional ESLint performance configuration for production TypeScript code.
  - Added checks for inefficient GPU uploads, hot-path allocations, unnecessary typed-array copies, and missing animation-frame, GPU-resource, or observer cleanup.
  - Added `@hotPath` support and automatic detection for common renderer methods.

- **Documentation**
  - Documented how to enable the performance configuration and its rules.

- **Tests**
  - Added comprehensive coverage for the configuration and performance checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->