### PR TITLE
chore(internals): add performance optimization skill

### DIFF
--- a/.agents/hooks/pre-tool-use-edit-write.sh
+++ b/.agents/hooks/pre-tool-use-edit-write.sh
@@ -14,13 +14,10 @@ fi
 
 # Protected slow-layer infrastructure files
 PROTECTED_FILES=(
-  "pnpm-workspace.yaml"
   "commitlint.config.js"
   "release.config.cjs"
-  "package.json"
   "pnpm-lock.yaml"
   ".nvmrc"
-  "mise.toml"
   "mise.lock"
   ".husky"
   "config"

--- a/.agents/skills/guidance-webgpu-performance/SKILL.md
+++ b/.agents/skills/guidance-webgpu-performance/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: guidance-webgpu-performance
+description: Diagnose and improve browser WebGPU rendering performance, including frame pacing, draw and state-submission overhead, buffer uploads, shaders, and JavaScript work on the render critical path. Use for slow or stuttering GPU-backed interfaces, rendering regressions, CPU/GPU bottleneck analysis, or renderer performance changes; do not use for general page-load or build performance without a rendering symptom.
+---
+
+# Optimize WebGPU Performance
+
+Find the limiting resource before changing the renderer. Produce a reproducible diagnosis that separates JavaScript preparation, browser/API submission, data transfer, and GPU execution, then make only changes supported by measurements.
+
+## Required context
+
+1. Read the repository `AGENTS.md` and the affected project's `DEVELOPMENT.md`.
+2. Inspect the render loop, update path, buffer and texture ownership, shader code, and resource lifecycle involved in the representative workload.
+3. Before adding or changing a benchmark, inspect the affected package's `package.json`, local Vitest benchmark configuration, existing `*.test.bench.ts` files, and any shared configuration they import. Do not assume another project's harness applies unchanged.
+4. Read [the performance diagnostic playbook](references/performance-diagnostics.md) when classifying a bottleneck, selecting instrumentation, or proposing an optimization.
+
+## Establish the performance question
+
+Define the workload and target before measuring:
+
+- Separate initialization, steady rendering, interactive updates, streaming updates, picking/readback, and cleanup. Do not combine them into one unexplained metric.
+- Record object and primitive counts, update frequency and size, draw/pass counts, canvas pixel dimensions, device-pixel ratio, transparency, anti-aliasing, and relevant renderer settings.
+- Choose the user-visible metric: frame budget and tail latency, update latency, throughput, startup time, or memory. FPS alone can hide missed frames behind the display's refresh-rate ceiling.
+- Preserve correctness and representative visual output. A faster result that omits required work is not an optimization.
+- Inspect `git status --short` and preserve unrelated changes. Record when measurements include a dirty worktree.
+
+## Classify before optimizing
+
+Use independent CPU and GPU evidence plus controlled perturbations. Do not infer a GPU bottleneck from low FPS or a CPU bottleneck from a busy render callback alone.
+
+1. Measure frame intervals and the JavaScript phases that prepare data, update scene state, encode commands, and submit work.
+2. Measure GPU pass duration asynchronously when the API and adapter expose timer queries. Treat the absence of timer-query support as a measurement limitation, not as zero GPU cost.
+3. Vary one dimension at a time: object or draw count, changed-record count, upload bytes, primitive count, canvas pixels, transparency, or pass count.
+4. Use diagnostic toggles that preserve most of the pipeline while removing one class of work. Compare render-disabled, update-frozen, upload-bypassed, reduced-resolution, and reduced-shader-cost cases as applicable.
+5. Classify the evidence as JavaScript/GC, API submission or state churn, transfer/synchronization, vertex/geometry, fragment/fill, shader compilation, resource allocation, or mixed/unknown.
+
+If the evidence remains ambiguous, propose the smallest next experiment instead of recommending a large rewrite.
+
+## Use repository CPU benchmarks correctly
+
+Discover the affected project's `test:bench` script, benchmark config, and `*.test.bench.ts` files before extending them. The repository's shared Vitest library benchmark configuration recognizes `src/**/*.test.bench.ts`, but the package's local config and `DEVELOPMENT.md` determine how to run it and what environment it uses.
+
+Treat an ordinary Vitest benchmark as a CPU microbenchmark unless its configured environment and measured callback show otherwise. Timing data generation, validation, packing, dirty-range handling, or calls that prepare upload bytes does not measure `GPUQueue.writeBuffer`, command execution, shaders, presentation, or frame pacing.
+
+Follow the affected package's established patterns:
+
+- Preserve its benchmark options so baseline and candidate results remain comparable. If the package has no precedent, choose explicit warmup, duration, and iteration settings and document them.
+- Create representative typed-array sources outside the timed callback when source creation is not under test.
+- Place construction inside the callback only when allocation or initialization is intentionally part of the measurement.
+- Compare steady-state reuse with replacement or growth, partial with full commits, and ordinary with worst-case data when those paths differ.
+- Use scaling series such as record count, changed percentage, and consumer fan-out to identify complexity and crossover points.
+- Consume results or state transitions so the benchmark exercises the measured path.
+- Name benchmarks with the workload size and operation. Add a paired reference when the result is otherwise difficult to interpret.
+
+Run commands from the affected project through mise and only when its `DEVELOPMENT.md` defines the script:
+
+```shell
+mise exec -- pnpm run test:bench
+mise exec -- pnpm run test:bench -- --outputJson=benchmark.json
+mise exec -- pnpm run test:bench -- --compare=benchmark.json
+```
+
+Keep baseline and candidate environment, workload, benchmark options, and worktree state comparable. Use browser instrumentation for any claim about GPU execution or end-to-end rendering.
+
+## Select evidence-backed changes
+
+Prefer reducing repeated work on the confirmed limiting path:
+
+- For JavaScript cost, look for per-frame allocation, repeated conversion or validation, matrix and bounds work, duplicate fan-out, cache invalidation, and avoidable DOM/reactive work.
+- For submission cost, reduce redundant state changes and API crossings; batch compatible draws or use instancing when the workload has enough repeated geometry to justify it.
+- For upload cost, reuse capacity, merge dirty ranges, batch compatible uploads, separate data by update frequency, and avoid creating upload views or typed arrays in hot loops.
+- For GPU cost, test culling, level of detail, overdraw and transparency, render resolution, attachment formats, anti-aliasing, texture sampling, and shader work according to the measured scaling behavior.
+- For initialization cost, reuse pipelines and resources, avoid duplicate compilation, and consider creation-time mapping only for static data.
+
+Treat advanced staging rings, indirect drawing, shader or compute rewrites, data-layout changes, and WebAssembly as experiments with added complexity. Require evidence that a simpler change cannot meet the target.
+
+Also inspect bind-group and pipeline reuse, write frequency, buffer-offset alignment, command/pass structure, shader compilation, texture and attachment churn, and asynchronous mapping or readback behavior.
+
+## Verify and report
+
+When the user asks only for diagnosis, report findings without changing code. When the user asks for an improvement, implement the smallest supported change and verify:
+
+1. the targeted baseline/candidate measurement under the same conditions;
+2. an integration measurement that exercises the real browser renderer when the claim extends beyond CPU preparation;
+3. relevant correctness, visual, and project tests from `DEVELOPMENT.md`;
+4. memory, variance, and another workload size when the change can trade one regime for another.
+
+Report the workload, environment, measurements and spread, bottleneck classification, evidence, change or recommendation, confidence, and remaining uncertainty. State explicitly whether each result is a CPU microbenchmark, JavaScript frame measurement, GPU timer result, or end-to-end observation.

--- a/.agents/skills/guidance-webgpu-performance/references/performance-diagnostics.md
+++ b/.agents/skills/guidance-webgpu-performance/references/performance-diagnostics.md
@@ -1,0 +1,101 @@
+# Browser GPU performance diagnostic playbook
+
+Use this reference to choose measurements and optimizations after defining a representative workload. Select only the checks relevant to the suspected bottleneck.
+
+## Separate the timelines
+
+More than one timeline can limit a frame:
+
+1. Application JavaScript updates state and prepares typed data.
+2. JavaScript calls WebGPU to upload resources and encode or submit commands.
+3. The browser and driver validate, translate, and schedule commands.
+4. The GPU executes vertex, fragment, compute, copy, and presentation work.
+5. Readback, queries, or resource reuse can force those timelines to synchronize.
+
+Without awaiting a WebGPU completion promise, wall-clock time around a render function measures CPU-side work in steps 1 and 2, not completed GPU execution. If the function awaits `GPUBuffer.mapAsync()` or `GPUQueue.onSubmittedWorkDone()`, it also includes synchronization waits. GPU timers cover scheduled GPU work, but not all JavaScript or browser overhead. Frame intervals include both pipelines plus scheduling and display cadence. Use at least two perspectives before assigning a bottleneck.
+
+## Instrument without adding a stall
+
+### JavaScript and frame pacing
+
+- Use `performance.now()` around stable phases such as scene update, culling, packing, upload calls, command encoding, and submission. Avoid timers inside every object iteration because instrumentation overhead can dominate small operations.
+- Inspect the browser performance profile for long tasks, garbage collection, repeated allocation, style or layout, event handlers, and gaps between animation frames.
+- Track frame intervals and useful percentiles. Also report missed-frame counts against the intended frame budget. Do not use a vsync-capped FPS average as the only metric.
+- Warm up shader, JIT, and cache paths before measuring steady state. Measure startup separately when it matters.
+
+### WebGPU GPU timing
+
+- Request the optional `timestamp-query` feature only when the adapter exposes it.
+- Place timestamps around the pass or command region to investigate, resolve queries, and read results after later frames so the render loop does not wait for the GPU.
+- Reuse query, resolve, and readback resources when practical. Keep validation and error-scope diagnostics out of the production hot path.
+- Do not put `queue.onSubmittedWorkDone()` in every frame to estimate GPU time. It observes queue completion and can serialize work; use it only for an intentional out-of-band boundary.
+
+## Interpret controlled perturbations
+
+| Observation                                                 | Likely limiting path                                                   | Next discriminating experiment                                                                |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| JavaScript time is high while GPU time is low               | data preparation, scene traversal, allocation/GC, or API submission    | freeze updates, bypass packing, then vary draw calls independently                            |
+| JavaScript time rises mainly with draw count                | command encoding, state changes, driver/API crossings                  | batch compatible draws, reuse state, or test instancing                                       |
+| Time rises mainly with changed records or uploaded bytes    | conversion, dirty-range handling, upload calls, or transfer bandwidth  | compare partial/full commits and one batched upload with equal bytes                          |
+| GPU time falls strongly with canvas pixel count             | fragment shading, overdraw, blending, attachments, or bandwidth        | reduce fragment work, transparency, attachment cost, or render scale one at a time            |
+| GPU time follows vertex or primitive count more than pixels | vertex shading, topology, geometry bandwidth, or raster setup          | simplify geometry, cull, add level of detail, or test instancing                              |
+| Intermittent spikes align with GC or allocation             | temporary arrays, objects, closures, resource creation, or cache churn | reuse scratch storage and move stable creation out of the frame                               |
+| First frames are slow but steady state is healthy           | pipeline/shader compilation, uploads, or resource initialization       | profile initialization and warmup separately; reuse or compile asynchronously where supported |
+| Readback or query frames stall                              | forced CPU/GPU synchronization                                         | defer and ring-buffer results; use `GPUBuffer.mapAsync()` for readback completion             |
+
+These are hypotheses, not proof. Mixed bottlenecks can shift after the first optimization.
+
+## Inspect the JavaScript critical path
+
+Look for work multiplied by object, layer, or frame count:
+
+- typed-array or `DataView` construction, `subarray` views, array literals, closures, iterator objects, and temporary matrices;
+- repeated data normalization, geometry validation, transparency classification, bounds computation, serialization, or coordinate conversion;
+- replacing buffers that have sufficient capacity, copying identical source data across layers, or preparing the same source more than once;
+- scanning a full data set for a small update, emitting many disjoint dirty ranges, or uploading inside loops;
+- repeated bind-group, pipeline, attachment, texture-view, or resource creation;
+- DOM queries, layout reads, style changes, Lit updates, and event work interleaved with animation-frame preparation;
+- promise chaining, readback, or query polling that delays the next frame.
+
+Cache or reuse only when ownership and invalidation remain correct. A stale or over-broad cache can trade speed for incorrect rendering or excessive memory.
+
+## WebGPU optimization candidates
+
+Select candidates based on the measured path:
+
+- Map static vertex or index buffers at creation when they do not need later queue writes. This only targets initialization.
+- Pack compatible attributes and interleave vertex data when it reduces buffer bindings and improves access locality.
+- Separate global, material, and per-object data so each class updates at its actual frequency.
+- Batch per-object uniform data into larger writes and use aligned offsets. Respect `minUniformBufferOffsetAlignment` and device limits.
+- Merge adjacent or overlapping dirty ranges. Compare fewer larger writes against excess bytes rather than assuming either extreme wins.
+- Reuse buffer capacity, bind groups, pipelines, samplers, texture views, query sets, and scratch typed arrays. Do not reuse single-use `GPUCommandEncoder` or `GPUCommandBuffer` instances.
+- Use instancing for sufficiently repeated geometry. Keep a direct path when grouping overhead outweighs saved draws.
+- Use mapped staging buffers as a pool or ring only when upload copies materially affect performance. Never wait for mapping inside the frame; remap resources asynchronously after submission.
+- Resize canvas and depth/color attachments only when their pixel dimensions change.
+- Consider indirect drawing, GPU culling, or compute preparation only when object-scale CPU submission is the demonstrated limit.
+
+## Use repository Vitest benchmarks as CPU evidence
+
+Discover benchmark support in the affected package rather than routing every investigation through one project:
+
+- Read the package's `DEVELOPMENT.md`, `package.json`, local Vitest benchmark config, and existing `*.test.bench.ts` files.
+- Follow any imported repository configuration, such as the shared library benchmark include for `src/**/*.test.bench.ts`.
+- Preserve local benchmark options and fixture conventions so comparisons stay compatible.
+- Add the benchmark beside the code under test or to the package's established benchmark entry point.
+- Keep expensive fixture creation outside the callback unless initialization is the target.
+
+Choose experiment axes that match the code path. Useful comparisons include small-to-large inputs, incremental-to-full updates, cold creation-to-steady reuse, one-to-many consumers, ordinary-to-worst-case data, and ergonomic-to-direct encoding. Add browser-side evidence for queue uploads, render passes, shaders, rasterization, presentation, or interaction.
+
+## Design a credible comparison
+
+- Keep browser version, GPU and driver, operating system, power mode, display refresh, canvas pixels, workload, and visibility state fixed.
+- Run baseline and candidate close together and repeat enough samples to expose variance or thermal drift. Prefer distributions and medians over a single best run.
+- Change one performance variable at a time where practical.
+- Include workloads below, near, and above the suspected crossover, extending far enough beyond it to amortize setup, memory, or grouping costs.
+- Check output equivalence with the relevant unit and visual tests. Measure memory when pooling, caching, batching, or duplicating buffers.
+- Do not add overlapping CPU phase timings and GPU pass timings as though they were sequential; browser and GPU work can overlap.
+- Do not translate an isolated microbenchmark percentage directly into expected end-to-end frame improvement.
+
+## Source basis
+
+- [WebGPU Speed and Optimization](https://webgpufundamentals.org/webgpu/lessons/webgpu-optimization.html) explains measurement of JavaScript and GPU work, vertex packing, data separation by update frequency, large aligned uniform buffers, mapped staging buffers, and additional advanced options.

--- a/.agents/skills/troubleshooting/SKILL.md
+++ b/.agents/skills/troubleshooting/SKILL.md
@@ -41,7 +41,7 @@ Read the [troubleshooting guide](projects/site/src/docs/internal/guidelines/trou
 
 4. **If the issue persists**, compare against a working reference component (badge, button, or card) to spot structural differences.
 
-## Additional References
+## References
 
 - [Troubleshooting Guide](/projects/site/src/docs/internal/guidelines/troubleshooting.md) - Common issues and solutions
 - [Testing Guidelines](/projects/site/src/docs/internal/guidelines/testing.md) - Test patterns

--- a/config/vale/styles/config/vocabularies/Elements/accept.txt
+++ b/config/vale/styles/config/vocabularies/Elements/accept.txt
@@ -376,6 +376,7 @@ additional
 microbenchmark
 sufficient
 shader
+shaders
 application
 readback
 rasterization

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
   },
   "lint-staged": {
     "!{projects/internals/metadata/static/**,projects/site/public/static/**}": "prettier --write --ignore-unknown",
-    "**/!(*.test|*.test.*).{ts,md}": "vale --config .vale.ini"
+    ".agents/**/!(*.test|*.test.*).{ts,md}": "vale --config .vale.ini --glob='!{**/starters/**,**/404/**,**/vendor/**,**/changelog/**,**/icons/**,**/generated/**,**/dist/**,**/LICENSE*,**/CHANGELOG*,**/*.test.*}'",
+    "{projects/*/src,projects/*/*/src}/**/!(*.test|*.test.*).{ts,md}": "vale --config .vale.ini --glob='!{**/starters/**,**/404/**,**/vendor/**,**/changelog/**,**/icons/**,**/generated/**,**/dist/**,**/LICENSE*,**/CHANGELOG*,**/*.test.*}'",
+    "{projects/*,projects/*/*}/README.md": "vale --config .vale.ini --glob='!{**/starters/**,**/404/**,**/vendor/**,**/changelog/**,**/icons/**,**/generated/**,**/dist/**,**/LICENSE*,**/CHANGELOG*,**/*.test.*}'"
   },
   "wireit": {
     "ci": {
@@ -286,10 +288,11 @@
       ]
     },
     "lint:vale": {
-      "command": "vale --config .vale.ini projects/*/src projects/*/README.md projects/*/*/src projects/*/*/README.md --glob='!{**/starters/**,**/404/**,**/vendor/**,**/changelog/**,**/icons/**,**/generated/**,**/dist/**,**/LICENSE*,**/CHANGELOG*,**/*.test.*}'",
+      "command": "vale --config .vale.ini .agents projects/*/src projects/*/README.md projects/*/*/src projects/*/*/README.md --glob='!{**/starters/**,**/404/**,**/vendor/**,**/changelog/**,**/icons/**,**/generated/**,**/dist/**,**/LICENSE*,**/CHANGELOG*,**/*.test.*}'",
       "files": [
         "./.vale.ini",
         "./config/vale/**/*",
+        "./.agents/**/*.{md,ts}",
         "./projects/*/src/**/*.{md,ts}",
         "./projects/*/README.md",
         "./projects/*/*/src/**/*.{md,ts}",

--- a/projects/internals/BUILD.md
+++ b/projects/internals/BUILD.md
@@ -162,7 +162,7 @@ The following are the repo wide tools that apply to all source code and projects
 
 - [Vale](https://vale.sh/)
 
-  Prose linter for documentation and JSDoc comments. Enforces consistent technical writing using the Google developer documentation style guide and write-good rules. Configuration is in `.vale.ini` with custom vocabulary and rules in `config/vale/styles/`. Vale runs against `*.md` and `*.ts` files in `projects/` source directories. mise installs the Vale binary for local development and CI.
+  Prose linter for documentation and JSDoc comments. Enforces consistent technical writing using the Google developer documentation style guide and write-good rules. Configuration is in `.vale.ini` with custom vocabulary and rules in `config/vale/styles/`. Vale runs against non-test `*.md` and `*.ts` files in configured project source directories and `.agents/`. Pre-commit and CI use the same target filter. mise installs the Vale binary for local development and CI.
 
 ## Testing
 


### PR DESCRIPTION
Introduced a new skill for diagnosing and improving WebGPU rendering performance, including guidelines for measuring and optimizing various aspects of GPU workloads. Added a performance diagnostic playbook to assist in identifying bottlenecks and selecting appropriate optimizations.

Blocked by: https://github.com/NVIDIA/elements/pull/243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for diagnosing and improving browser-based WebGPU rendering performance.
  * Documented measurement-first workflows for identifying CPU and GPU bottlenecks.
  * Added recommendations for benchmarking, instrumentation, optimization validation, synchronization, and correctness testing.
  * Expanded documentation linting coverage to include agent guidance and project README files.
  * Clarified the scope of Markdown and TypeScript documentation checks.
  * Renamed a troubleshooting documentation section to “References.”

* **Style**
  * Updated terminology support to recognize “shaders” in documentation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->