### PR TITLE
fix(lint): allow external svg icon sources

### DIFF
--- a/projects/lint/src/eslint/rules/no-unexpected-attribute-value.test.ts
+++ b/projects/lint/src/eslint/rules/no-unexpected-attribute-value.test.ts
@@ -96,6 +96,17 @@ describe('noUnexpectedAttributeValue', () => {
     });
   });
 
+  it('should allow external SVG sources for icons', () => {
+    tester.run('should allow external SVG sources for icons', rule, {
+      valid: [
+        `<nve-icon name="my-image.svg"></nve-icon>`,
+        `<nve-icon name="./my-image.svg"></nve-icon>`,
+        `<nve-icon name="/static/images/my-image.svg"></nve-icon>`
+      ],
+      invalid: []
+    });
+  });
+
   it('should allow template bindings in attribute values', () => {
     tester.run('should allow template bindings', rule, {
       valid: [

--- a/projects/lint/src/eslint/rules/no-unexpected-attribute-value.ts
+++ b/projects/lint/src/eslint/rules/no-unexpected-attribute-value.ts
@@ -11,6 +11,10 @@ import { attributeValueIsDeprecatedForTag } from './no-deprecated-attributes.js'
 declare const __ELEMENTS_PAGES_BASE_URL__: string;
 const VALUE_BINDINGS = ['${', '{', '{{', '{%'];
 
+function isExternalIconSource(tagName: string, attributeName: string, value: string) {
+  return tagName === 'nve-icon' && attributeName === 'name' && value.endsWith('.svg');
+}
+
 const rule = {
   meta: {
     type: 'problem' as const,
@@ -44,7 +48,8 @@ const rule = {
             attr =>
               attr.type === 'Attribute' &&
               attr.key?.value &&
-              !VALUE_BINDINGS.some(binding => attr.value?.value?.includes(binding))
+              !VALUE_BINDINGS.some(binding => attr.value?.value?.includes(binding)) &&
+              !isExternalIconSource(tagName, attr.key.value, attr.value?.value ?? '')
           )
           .forEach((attr: HtmlAttribute) => {
             const attributeName = attr.key!.value;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - External SVG paths are now accepted as `nve-icon` `name` attribute values, including bare, relative, and absolute paths.
  - These values no longer trigger unexpected attribute-value validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->