### PR TITLE
fix(docs): make page title weights consistent

### DIFF
--- a/projects/site/src/_11ty/libraries/markdown.js
+++ b/projects/site/src/_11ty/libraries/markdown.js
@@ -42,7 +42,7 @@ markdown.renderer.rules.fence = function (tokens, idx, options, env, slf) {
 };
 
 const formats = {
-  h1: 'display emphasis',
+  h1: 'display emphasis semibold',
   h2: 'heading xl emphasis',
   h3: 'heading lg emphasis',
   h4: 'heading',

--- a/projects/site/src/index.md
+++ b/projects/site/src/index.md
@@ -12,7 +12,7 @@
   }
 </style>
 <div nve-layout="column gap:lg pad-top:lg">
-  <h1 nve-text="display sm">NVIDIA Elements</h1>
+  <h1 nve-text="display sm semibold">NVIDIA Elements</h1>
   <h2 nve-text="heading">The Design Language and UI Agent Harness for AI/ML Factories, Robotics, and Autonomous Vehicles</h2>
 </div>
 <nve-divider></nve-divider>


### PR DESCRIPTION
- make Markdown and landing-page titles consistent with component page-title typography

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the “NVIDIA Elements” page heading to use semibold typography for improved visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->