### PR TITLE
fix(docs): align list item title presentation

### DIFF
--- a/projects/site/src/docs/foundations/index.md
+++ b/projects/site/src/docs/foundations/index.md
@@ -28,7 +28,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="typography"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Typography</h2>
+          <h2 nve-text="label medium emphasis">Typography</h2>
           <p nve-text="body sm muted">Type scale, weights, and text utilities for readable interfaces.</p>
         </div>
       </div>
@@ -41,7 +41,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="shapes"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Iconography</h2>
+          <h2 nve-text="label medium emphasis">Iconography</h2>
           <p nve-text="body sm muted">Searchable icon catalog and guidance for nve-icon usage.</p>
         </div>
       </div>
@@ -54,7 +54,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="color-palette"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Themes</h2>
+          <h2 nve-text="label medium emphasis">Themes</h2>
           <p nve-text="body sm muted">Design tokens, color, and CSS custom properties for theming.</p>
         </div>
       </div>
@@ -67,7 +67,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="view-as-grid"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Layout</h2>
+          <h2 nve-text="label medium emphasis">Layout</h2>
           <p nve-text="body sm muted">Flexbox and grid utilities for responsive arrangements.</p>
         </div>
       </div>
@@ -80,7 +80,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="picture-in-picture"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Popovers</h2>
+          <h2 nve-text="label medium emphasis">Popovers</h2>
           <p nve-text="body sm muted">Native popover APIs for overlays, menus, and tooltips.</p>
         </div>
       </div>
@@ -93,7 +93,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="globe"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">i18n</h2>
+          <h2 nve-text="label medium emphasis">i18n</h2>
           <p nve-text="body sm muted">Internationalization and localization defaults built in.</p>
         </div>
       </div>
@@ -106,7 +106,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="chart-bar"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Visualization</h2>
+          <h2 nve-text="label medium emphasis">Visualization</h2>
           <p nve-text="body sm muted">Primitives for charts, trends, and data display.</p>
         </div>
       </div>
@@ -119,7 +119,7 @@ Foundations are the shared visual system behind every NVIDIA Elements interface.
           <nve-icon name="sparkles"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">View Transitions</h2>
+          <h2 nve-text="label medium emphasis">View Transitions</h2>
           <p nve-text="body sm muted">Smooth animated transitions between page views.</p>
         </div>
       </div>

--- a/projects/site/src/docs/integrations/index.11ty.js
+++ b/projects/site/src/docs/integrations/index.11ty.js
@@ -18,11 +18,11 @@ const renderLogo = ({ icon, iconHeight, iconSize = '36px', iconWidth, nveIcon, t
 };
 
 const renderIntegration = integration => /* html */ `<a href="${integration.href}">
-    <nve-card>
+    <nve-card style="--border-radius: var(--nve-ref-border-radius-md)">
       <div nve-layout="row gap:sm align:vertical-center">
         ${renderLogo(integration)}
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">${integration.title}</h2>
+          <h2 nve-text="label medium emphasis">${integration.title}</h2>
           <p nve-text="body sm muted">${integration.description}</p>
         </div>
       </div>

--- a/projects/site/src/docs/patterns/index.md
+++ b/projects/site/src/docs/patterns/index.md
@@ -28,7 +28,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="lock"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Authentication</h2>
+          <h2 nve-text="label medium emphasis">Authentication</h2>
           <p nve-text="body sm muted">Login, authentication, and verification patterns.</p>
         </div>
       </div>
@@ -41,7 +41,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="browser"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Browse</h2>
+          <h2 nve-text="label medium emphasis">Browse</h2>
           <p nve-text="body sm muted">Browse collections or lists of content</p>
         </div>
       </div>
@@ -54,7 +54,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="chat-bubble"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Chat</h2>
+          <h2 nve-text="label medium emphasis">Chat</h2>
           <p nve-text="body sm muted">Chat and AI conversation patterns</p>
         </div>
       </div>
@@ -67,7 +67,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="carets-closed-square"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Editor</h2>
+          <h2 nve-text="label medium emphasis">Editor</h2>
           <p nve-text="body sm muted">Code and Content Editing Patterns</p>
         </div>
       </div>
@@ -80,7 +80,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="rectangle-group"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Dashboard</h2>
+          <h2 nve-text="label medium emphasis">Dashboard</h2>
           <p nve-text="body sm muted">Common dashboard layouts and patterns.</p>
         </div>
       </div>
@@ -93,7 +93,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="question-mark-circle-stroke"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Empty States</h2>
+          <h2 nve-text="label medium emphasis">Empty States</h2>
           <p nve-text="body sm muted">Patterns and messaging for unavailable or missing data</p>
         </div>
       </div>
@@ -106,7 +106,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="table"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Heatmap</h2>
+          <h2 nve-text="label medium emphasis">Heatmap</h2>
           <p nve-text="body sm muted">Heatmap patterns and implementation examples</p>
         </div>
       </div>
@@ -119,7 +119,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="keyboard"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Keyboard Shortcuts</h2>
+          <h2 nve-text="label medium emphasis">Keyboard Shortcuts</h2>
           <p nve-text="body sm muted">Common keyboard shortcut patterns</p>
         </div>
       </div>
@@ -132,7 +132,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="terminal"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Logging</h2>
+          <h2 nve-text="label medium emphasis">Logging</h2>
           <p nve-text="body sm muted">Common logging and timeline lists</p>
         </div>
       </div>
@@ -145,7 +145,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="video-camera"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Media</h2>
+          <h2 nve-text="label medium emphasis">Media</h2>
           <p nve-text="body sm muted">Media content patterns and layouts</p>
         </div>
       </div>
@@ -158,7 +158,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="map"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Navigation</h2>
+          <h2 nve-text="label medium emphasis">Navigation</h2>
           <p nve-text="body sm muted">Common navigation patterns and structure</p>
         </div>
       </div>
@@ -171,7 +171,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="shapes"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Onboarding</h2>
+          <h2 nve-text="label medium emphasis">Onboarding</h2>
           <p nve-text="body sm muted">Guided UX steps and processes</p>
         </div>
       </div>
@@ -184,7 +184,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="dock-side"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Panel</h2>
+          <h2 nve-text="label medium emphasis">Panel</h2>
           <p nve-text="body sm muted">In view context details and actions</p>
         </div>
       </div>
@@ -197,7 +197,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="transparent-box"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Responsive</h2>
+          <h2 nve-text="label medium emphasis">Responsive</h2>
           <p nve-text="body sm muted">Adaptive overflow with container queries</p>
         </div>
       </div>
@@ -210,7 +210,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="search"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Search</h2>
+          <h2 nve-text="label medium emphasis">Search</h2>
           <p nve-text="body sm muted">Search and progressive filtering</p>
         </div>
       </div>
@@ -223,7 +223,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="heading"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Subheader</h2>
+          <h2 nve-text="label medium emphasis">Subheader</h2>
           <p nve-text="body sm muted">Common subheader navigation and actions</p>
         </div>
       </div>
@@ -236,7 +236,7 @@ Patterns are an essential component of creating a cohesive and consistent user e
           <nve-icon name="trend-up"></nve-icon>
         </nve-logo>
         <div nve-layout="column pad:xs gap:xs">
-          <h2 nve-text="label medium">Trend</h2>
+          <h2 nve-text="label medium emphasis">Trend</h2>
           <p nve-text="body sm muted">Simple data trend representations</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- align integration card corner radius with the Foundations and Patterns collections
- use the shared emphasized label treatment for card titles across Integrations, Foundations, and Patterns

## Validation

- Vale
- Prettier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated foundation and pattern card headings with emphasized label styling.
  * Applied emphasized title styling to integration cards.
  * Standardized integration card corners with a medium border radius.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->