### PR TITLE
fix(docs): fix background for component subheaders

### DIFF
--- a/projects/site/src/_11ty/layouts/docs.css
+++ b/projects/site/src/_11ty/layouts/docs.css
@@ -53,7 +53,7 @@ body {
 
 /* Sticky Subheader Styles */
 section[slot='subheader'] {
-  background: var(--nve-ref-color-neutral-100);
+  background: var(--nve-sys-layer-canvas-background);
   border-bottom: 1px solid var(--nve-ref-border-color);
 
   /* Override nve-layout values with animated values */


### PR DESCRIPTION
## Summary

- currently in light mode you can see the visual inconsistency so replace the component documentation header’s neutral background with the semantic canvas background token
- keep sthe sticky header visually consistent with the active system layer and theme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sticky subheader background to use the canvas background color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->