### PR TITLE
fix(docs): styling consistency of navigation group titles

### DIFF
--- a/projects/site/src/_11ty/layouts/docs.css
+++ b/projects/site/src/_11ty/layouts/docs.css
@@ -79,13 +79,11 @@ section[slot='subheader'] {
 #sidenav-panel {
   nve-tree > nve-tree-node:not(:has(> a)),
   nve-tree > nve-tree-node:has(> a) {
-    --color: var(--nve-sys-text-muted-color);
-    --font-size: 11px;
+    --color: var(--nve-sys-text-emphasis-color);
+    --font-size: var(--nve-ref-font-size-200);
     --border-radius: var(--nve-ref-border-radius-xs);
-    font-weight: var(--nve-ref-font-weight-regular);
+    --font-weight: var(--nve-ref-font-weight-medium);
     margin-block-end: var(--nve-ref-space-sm);
-    text-transform: uppercase;
-    letter-spacing: 1.76px;
     cursor: pointer;
   }
 


### PR DESCRIPTION
## Summary

The current type styling of the navigation is a vestigial styling from storybook and limitations of theming customizations. This Improves the presentation consistency of documentation navigation group titles with how its manifested in this system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated documentation sidebar navigation with emphasized text, design-token sizing, and medium font weight.
  * Removed uppercase lettering, extra spacing, muted coloring, smaller text, and regular-weight styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->