### PR TITLE
fix(docs): correct jsdelivr bundle urls

### DIFF
--- a/projects/site/src/_internal/canvas-editable/canvas-editable.ts
+++ b/projects/site/src/_internal/canvas-editable/canvas-editable.ts
@@ -214,9 +214,9 @@ export class CanvasEditable extends LitElement {
     }
 
     return {
-      elements: `${__ELEMENTS_CDN_BASE_URL__}/@nvidia-elements/core/${this.packageVersions.elements}/dist/bundles/index.js`,
-      themes: `${__ELEMENTS_CDN_BASE_URL__}/@nvidia-elements/themes/${this.packageVersions.themes}/dist/bundles/index.css`,
-      styles: `${__ELEMENTS_CDN_BASE_URL__}/@nvidia-elements/styles/${this.packageVersions.styles}/dist/bundles/index.css`
+      elements: `${__ELEMENTS_CDN_BASE_URL__}/@nvidia-elements/core@${this.packageVersions.elements}/dist/bundles/index.js`,
+      themes: `${__ELEMENTS_CDN_BASE_URL__}/@nvidia-elements/themes@${this.packageVersions.themes}/dist/bundles/index.css`,
+      styles: `${__ELEMENTS_CDN_BASE_URL__}/@nvidia-elements/styles@${this.packageVersions.styles}/dist/bundles/index.css`
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CDN bundle URLs to use the correct package and version path format for elements, themes, and styles.
  * Localhost bundle resolution remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->